### PR TITLE
Refactor handlers to return result instead of being part of the context.

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -7,7 +7,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
     <DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
-    <DetectedMSBuildVersion Condition="$(MSBuildVersion) == ''">15.0.0</DetectedMSBuildVersion>
+    <DetectedMSBuildVersion Condition="'$(MSBuildVersion)' == ''">15.0.0</DetectedMSBuildVersion>
     <MSBuildSupportsHashing>false</MSBuildSupportsHashing>
     <MSBuildSupportsHashing Condition=" '$(DetectedMSBuildVersion)' &gt; '15.8.0' ">true</MSBuildSupportsHashing>
     <!-- Mark that this target file has been loaded.  -->
@@ -27,44 +27,13 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
-    <!-- Paket -->
-
-    <!-- windows, root => tool => proj style => bootstrapper => global -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
-
-    <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
-
-    <!-- no windows, try mono paket -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-
-    <!-- no windows, try bootstrapper -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
-
-    <!-- no windows, try global native paket -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
-
-    <!-- Paket command -->
-    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
-
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
     <!-- Disable automagic references for F# dotnet sdk -->
     <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
@@ -74,6 +43,57 @@
     <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- Check if paket is available as local dotnet cli tool -->
+  <Target Name="SetPaketCommand" >
+  
+    <!-- Call 'dotnet paket' and see if it returns without an error. Mute all the output. -->
+    <Exec Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+      <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
+    </Exec>
+
+    <!-- If local paket tool is found, use that -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' == '0' ">
+      <InternalPaketCommand>dotnet paket</InternalPaketCommand>
+    </PropertyGroup>
+
+    <!-- If not, then we go through our normal steps of setting the Paket command.  -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' != '0' ">
+      <!-- windows, root => tool => proj style => bootstrapper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+
+      <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+
+      <!-- no windows, try mono paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+      <!-- no windows, try bootstrapper -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+      <!-- no windows, try global native paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
+
+      <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' ">"$(PaketExePath)"</InternalPaketCommand>
+
+    </PropertyGroup>
+
+    <!-- The way to get a property to be available outside the target is to use this task. -->
+    <CreateProperty Value="$(InternalPaketCommand)">
+      <Output TaskParameter="Value" PropertyName="PaketCommand"/>
+    </CreateProperty>
+
+  </Target>
+
   <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
     <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
   </Target>
@@ -81,7 +101,7 @@
   <!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
   <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
   <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
-  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="PaketBootstrapping">
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="SetPaketCommand;PaketBootstrapping">
 
     <!-- Step 1 Check if lockfile is properly restored (if the hash of the lockfile and the cache-file match) -->
     <PropertyGroup>
@@ -203,7 +223,7 @@
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
-        <CopyLocal Condition="'$(Splits)' == '6'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
+        <CopyLocal Condition="'%(PaketReferencesFileLinesInfo.Splits)' == '6'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
@@ -246,7 +266,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
+  <Target Name="PaketOverrideNuspec" DependsOnTargets="SetPaketCommand" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <ItemGroup>
       <_NuspecFilesNewLocation Include="$(PaketIntermediateOutputPath)\$(Configuration)\*.nuspec"/>
       <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
@@ -300,7 +320,7 @@
               DevelopmentDependency="$(DevelopmentDependency)"
               BuildOutputInPackage="@(_BuildOutputInPackage)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              SymbolPackageFormat="symbols.nupkg"
+              SymbolPackageFormat="$(SymbolPackageFormat)"
               TargetFrameworks="@(_TargetFrameworks)"
               AssemblyName="$(AssemblyName)"
               PackageOutputPath="$(PackageOutputAbsolutePath)"
@@ -347,7 +367,7 @@
               DevelopmentDependency="$(DevelopmentDependency)"
               BuildOutputInPackage="@(_BuildOutputInPackage)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
-              SymbolPackageFormat="symbols.nupkg"
+              SymbolPackageFormat="$(SymbolPackageFormat)"
               TargetFrameworks="@(_TargetFrameworks)"
               AssemblyName="$(AssemblyName)"
               PackageOutputPath="$(PackageOutputAbsolutePath)"

--- a/README.md
+++ b/README.md
@@ -3,34 +3,33 @@
 [![Build](https://img.shields.io/travis/cognitedata/oryx)](https://travis-ci.org/cognitedata/oryx)
 [![codecov](https://codecov.io/gh/cognitedata/oryx/branch/master/graph/badge.svg)](https://codecov.io/gh/cognitedata/oryx)
 [![Nuget](https://img.shields.io/nuget/v/oryx)](https://www.nuget.org/packages/Oryx/)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-0f69b4.svg)](code-of-conduct.md)
 
-Oryx is a high performance .NET cross platform functional HTTP request handler library for writing web client libraries in F#.
+Oryx is a high performance .NET cross platform functional HTTP request handler library for writing HTTP web clients in F#.
 
 > An SDK for writing HTTP web clients or SDKs.
 
-This library enables you to write (or generate) Web and REST clients and SDKs for various APIs. Thus Oryx is an SDK for writing SDKs.
+This library enables you to write Web and REST clients and SDKs for various APIs and is currently used by the [.NET SDK for Cognite Data Fusion (CDF)](https://github.com/cognitedata/cognite-sdk-dotnet).
 
-You can think of Oryx as the client equivalent of Giraffe. Oryx is heavily inspired by the [Giraffe](https://github.com/giraffe-fsharp/Giraffe) web framework, and applies the same ideas to the client making the web requests. Thus you could envision the processing pipeline starting at the client and going all the way to the server and back again.
+Oryx is heavily inspired by the [Giraffe](https://github.com/giraffe-fsharp/Giraffe) web framework, and applies the same ideas to the client making the web requests. You can think of Oryx as the client equivalent of Giraffe, and you could envision the HTTP request processing pipeline starting at the client and going all the way to the server and back again.
 
 ## Fundamentals
 
-The main building blocks in Oryx is the `Context` and the `HttpHandler`. The Context stores all the state needed for performing the request and any data received from the response:
+The main building blocks in Oryx is the `Context` and the `HttpHandler`. The Context stores all the state needed for making the request and any response or error received from the server:
 
 ```fs
 type Context<'a> = {
     Request: HttpRequest
-    Result: Result<'a, ResponseError>
+    Response: 'a
 }
 ```
 
-The `Context` is transformed by HTTP handlers. The `HttpHandler` takes a `Context` (and a `NextFunc`) and returns a new `Context`.
+The `Context` may be transformed by series of HTTP handlers. The `HttpHandler` takes a `Context` (and a `NextFunc`) and returns a new `Context`.
 
 ```fs
-type HttpFunc<'a, 'b> = Context<'a> -> Task<Context<'b>>
+type HttpFunc<'a, 'b> = Context<'a> -> Task<Result<Context<'b>, ResponseError>>
 type NextFunc<'a, 'b> = HttpFunc<'a, 'b>
 
-type HttpHandler<'a, 'b, 'c> = NextFunc<'b, 'c> -> Context<'a> -> Task<Context<'c>>
+type HttpHandler<'a, 'b, 'c> = NextFunc<'b, 'c> -> Context<'a> -> Task<Result<Context<'c>, ResponseError>>
 
 // For convenience
 type HttpHandler<'a, 'b> = HttpHandler<'a, 'a, 'b>
@@ -38,19 +37,23 @@ type HttpHandler<'a> = HttpHandler<HttpResponseMessage, 'a>
 type HttpHandler = HttpHandler<HttpResponseMessage>
 ```
 
-An `HttpHandler` is a plain function that takes two curried arguments, and `NextFunc` and a `Context`, and returns a `Context` (wrapped in a `Result` and `Task`) when finished.
+An `HttpHandler` is a plain function that takes two curried arguments, a `NextFunc` and a `Context`, and returns a new `Context` (wrapped in a `Result` and `Task`) when finished. On a high level the `HttpHandler` function takes and returns a context object, which means every `HttpHandler` function has full control of the outgoing `HttpRequest` and also the resulting response.
 
-On a high level the `HttpHandler` function takes and returns a context object, which means every `HttpHandler` function has full control of the outgoing `HttpRequest` and also the resulting response.
-
-Each HttpHandler usually adds more info to the `HttpRequest` before passing it further down the pipeline by invoking the next `NextFunc` or short circuit the execution by returning a result of `Result<'a, ResponseError>`.
+Each HttpHandler usually adds more info to the `HttpRequest` before passing it further down the pipeline by invoking the next `NextFunc` or short circuit the execution by returning a result of `Result<Context<'a>, ResponseError>`.
 
 If an HttpHandler detects an error, then it can return `Result.Error` to fail the processing.
 
-The easiest way to get your head around a Oryx `HttpHandler` is to think of it as a functional Web request processing pipeline. Each handler has the full `Context` at its disposal and can decide whether it wants to return `Error` or pass on a new `Context` on to the "next" handler, `NextFunc`.
+The easiest way to get your head around a Oryx `HttpHandler` is to think of it as a functional Web request processing pipeline. Each handler has the full `Context` at its disposal and can decide whether it wants to fail the request by returning an `Error`, or continue the request by passing on a new `Context` to the "next" handler, `NextFunc`.
+
+The more complex way to think about a `HttpHandler` is that there are in fact 3 different ways it may process the request:
+
+1. Call the next handler with an `Ok` result value, and return what the next handler is returning.
+2. Return an `Error`result to fail the request.
+3. Return `Ok` to short circuit the processing. This is not something you would normally do.
 
 ## Operators
 
-The fact that everything is an `HttpHandler` makes it easy to compose handlers together. You can think of them as lego bricks that you can put together. Two `HttpHandler` functions may be composed together using Keisli compsition, i.e using the fish operator `>=>`.
+The fact that everything is an `HttpHandler` makes it easy to compose handlers together. You can think of them as lego bricks that you can fit together. Two `HttpHandler` functions may be composed together using Keisli compsition, i.e using the fish operator `>=>`.
 
 ```fs
 let (>=>) a b = compose a b
@@ -69,19 +72,23 @@ let compose (first : HttpHandler<'a, 'b, 'd>) (second : HttpHandler<'b, 'c, 'd>)
         func ctx
 ```
 
-This enables you to compose your web requests and decode the response, e.g:
+This enables you to compose your web requests and decode the response, e.g as we do when listing Assets in the  the [Cognite Data Fusion SDK](https://github.com/cognitedata/cognite-sdk-dotnet/blob/master/src/assets/ListAssets.fs#L55):
 
 ```fs
-let listAssets (options: Option seq) (fetch: HttpHandler<HttpResponseMessage,Stream, 'a>) =
-    let decoder = Encode.decodeResponse Assets.Decoder id
-    let query = options |> Seq.map Option.Render |> List.ofSeq
+    let listAssets (options: AssetQuery seq) (filters: AssetFilter seq) (fetch: HttpHandler<HttpResponseMessage, 'a>) =
+        let decodeResponse = Decode.decodeContent AssetItemsReadDto.Decoder id
+        let request : Request = {
+            Filters = filters
+            Options = options
+        }
 
-    GET
-    >=> setVersion V10
-    >=> addQuery query
-    >=> setResource Url
-    >=> fetch
-    >=> decoder
+        POST
+        >=> setVersion V10
+        >=> setContent (Content.JsonValue request.Encoder)
+        >=> setResource Url
+        >=> fetch
+        >=> Decode.decodeError
+        >=> decodeResponse
 ```
 
 Thus the function `listAssets` is now also an `HttpHandler` and may be composed with other handlers to create complex chains for doing series of multiple requests to a web service.

--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -8,9 +8,9 @@ open FSharp.Control.Tasks.V2.ContextInsensitive
 
 type RequestBuilder () =
     member this.Zero () : HttpHandler<HttpResponseMessage, HttpResponseMessage, _> = fun next _ -> next Context.defaultContext
-    member this.Return (res: 'a) : HttpHandler<HttpResponseMessage, 'a, _> = fun next _ ->  next { Request = Context.defaultRequest; Result = Ok res }
+    member this.Return (res: 'a) : HttpHandler<HttpResponseMessage, 'a, _> = fun next _ ->  next { Request = Context.defaultRequest; Response = res }
 
-    member this.Return (req: HttpRequest) : HttpHandler<HttpResponseMessage, HttpResponseMessage, _> = fun next ctx -> next { Request = req; Result = Context.defaultResult }
+    member this.Return (req: HttpRequest) : HttpHandler<HttpResponseMessage, HttpResponseMessage, _> = fun next ctx -> next { Request = req; Response = Context.defaultResult }
 
     member this.ReturnFrom (req : HttpHandler<'a, 'b, 'c>)  : HttpHandler<'a, 'b, 'c> = req
 
@@ -24,12 +24,8 @@ type RequestBuilder () =
     member this.Bind(source: HttpHandler<'a, 'b, 'd>, fn: 'b -> HttpHandler<'a, 'c, 'd>) :  HttpHandler<'a, 'c, 'd> =
         fun (next : NextFunc<'c, 'd>) (ctx : Context<'a>) ->
             let next' (cb : Context<'b>) = task {
-                match cb.Result with
-                | Ok b ->
-                    // Run function
-                    return! (fn b) next ctx
-                | Error error ->
-                    return { Request = cb.Request; Result = Error error }
+                // Run function
+                return! (fn cb.Response) next ctx
             }
             // Run source
             source next' ctx

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -92,17 +92,6 @@ module Context =
     let bind (fn: 'a -> Context<'b>) (ctx: Context<'a>) : Context<'b> =
         fn ctx.Response
 
-    (*
-    let bindAsync (fn: Context<'a> -> Task<Context<'b>>) (a: Task<Context<'a>>) : Task<Context<'b>> =
-        task {
-            let! p = a
-            match p.Result with
-            | Ok _ ->
-                return! fn p
-            | Error err ->
-                return { Request = p.Request; Result = Error err }
-        }
-    *)
     /// Add HTTP header to context.
     let addHeader (header: string*string) (context: HttpContext) =
         { context with Request = { context.Request with Headers = header :: context.Request.Headers  } }

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -7,9 +7,7 @@ open System.Net
 open System.Net.Http
 open System.Reflection
 open System.Threading
-open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
 open Thoth.Json.Net
 
 type RequestMethod =
@@ -73,9 +71,7 @@ module Context =
             Content = None
             Query = List.empty
             ResponseType = JsonValue
-            Headers = [
-                "User-Agent", ua
-            ]
+            Headers = [ "User-Agent", ua ]
             UrlBuilder = fun _ -> String.Empty
             Extra = Map.empty
             CancellationToken = None

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -54,7 +54,7 @@ and HttpRequest = {
 
 type Context<'a> = {
     Request: HttpRequest
-    Result: Result<'a, ResponseError>
+    Response: 'a
 }
 
 type HttpContext = Context<HttpResponseMessage>
@@ -82,20 +82,17 @@ module Context =
         }
 
     let internal defaultResult =
-        Ok (new HttpResponseMessage (HttpStatusCode.NotFound))
+        new HttpResponseMessage (HttpStatusCode.NotFound)
 
     let defaultContext : Context<HttpResponseMessage> = {
         Request = defaultRequest
-        Result = defaultResult
+        Response = defaultResult
     }
 
-    let bind fn ctx =
-        match ctx.Result with
-        | Ok res ->
-            fn res
-        | Error err ->
-            { Request = ctx.Request; Result = Error err }
+    let bind (fn: 'a -> Context<'b>) (ctx: Context<'a>) : Context<'b> =
+        fn ctx.Response
 
+    (*
     let bindAsync (fn: Context<'a> -> Task<Context<'b>>) (a: Task<Context<'a>>) : Task<Context<'b>> =
         task {
             let! p = a
@@ -105,7 +102,7 @@ module Context =
             | Error err ->
                 return { Request = p.Request; Result = Error err }
         }
-
+    *)
     /// Add HTTP header to context.
     let addHeader (header: string*string) (context: HttpContext) =
         { context with Request = { context.Request with Headers = header :: context.Request.Headers  } }

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -19,26 +19,6 @@ open Thoth.Json.Net
 
 [<AutoOpen>]
 module Fetch =
-    /// Add query parameters to context. These parameters will be added
-    /// to the query string of requests that uses this context.
-    let addQuery (query: (string * string) list) (next: NextFunc<_,_>) (context: HttpContext) =
-        next { context with Request = { context.Request with Query = query } }
-
-    /// Add content to context. These content will be added to the HTTP body of
-    /// requests that uses this context.
-    let setContent (content: Content) (next: NextFunc<_,_>) (context: HttpContext) =
-        next { context with Request = { context.Request with Content = Some content } }
-
-    let setResponseType (respType: ResponseType) (next: NextFunc<_,_>) (context: HttpContext) =
-        next { context with Request = { context.Request with ResponseType = respType }}
-
-    /// Set the method to be used for requests using this context.
-    let setMethod<'a> (method: HttpMethod) (next: NextFunc<HttpResponseMessage,'a>) (context: HttpContext) =
-        next { context with Request = { context.Request with Method = method; Content = None } }
-
-    let GET<'a> = setMethod<'a> HttpMethod.Get
-    let POST<'a> = setMethod<'a> HttpMethod.Post
-    let DELETE<'a> = setMethod<'a> HttpMethod.Delete
 
     /// HttpContent implementation to push a JsonValue directly to the output stream.
     type JsonPushStreamContent (content : JsonValue) =

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -102,7 +102,7 @@ module Fetch =
             request.Content <- content
         request
 
-    let fetch<'a> (next: NextFunc<HttpResponseMessage, 'a>) (ctx: HttpContext) : Task<Context<'a>> =
+    let fetch<'a> (next: NextFunc<HttpResponseMessage, 'a>) (ctx: HttpContext) :  HttpFuncResult<'a> =
         let client =
             match ctx.Request.HttpClient with
             | Some client -> client
@@ -118,9 +118,9 @@ module Fetch =
             try
                 use message = buildRequest client ctx
                 use! response = client.SendAsync(message, cancellationToken)
-                return! next { Request = ctx.Request; Result = Ok response }
+                return! next { Request = ctx.Request; Response = response }
             with
             | ex ->
                 let error = ResponseError.empty
-                return { Request = ctx.Request; Result = Error { error with InnerException = Some ex } }
+                return Error { error with InnerException = Some ex }
         }

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -46,6 +46,27 @@ module Handler =
     let (>=>) a b =
         compose a b
 
+    /// Add query parameters to context. These parameters will be added
+    /// to the query string of requests that uses this context.
+    let addQuery (query: (string * string) list) (next: NextFunc<_,_>) (context: HttpContext) =
+        next { context with Request = { context.Request with Query = query } }
+
+    /// Add content to context. These content will be added to the HTTP body of
+    /// requests that uses this context.
+    let setContent (content: Content) (next: NextFunc<_,_>) (context: HttpContext) =
+        next { context with Request = { context.Request with Content = Some content } }
+
+    let setResponseType (respType: ResponseType) (next: NextFunc<_,_>) (context: HttpContext) =
+        next { context with Request = { context.Request with ResponseType = respType }}
+
+    /// Set the method to be used for requests using this context.
+    let setMethod<'a> (method: HttpMethod) (next: NextFunc<HttpResponseMessage,'a>) (context: HttpContext) =
+        next { context with Request = { context.Request with Method = method; Content = None } }
+
+    let GET<'a> = setMethod<'a> HttpMethod.Get
+    let POST<'a> = setMethod<'a> HttpMethod.Post
+    let DELETE<'a> = setMethod<'a> HttpMethod.Delete
+
     /// Run list of HTTP handlers concurrently.
     let concurrent (handlers : HttpHandler<'a, 'b, 'b> seq) (next: NextFunc<'b list, 'c>) (ctx: Context<'a>) : HttpFuncResult<'c> = task {
         let! res =

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -6,11 +6,12 @@ open System.Net.Http
 open System.Threading.Tasks
 open FSharp.Control.Tasks.V2.ContextInsensitive
 
-type HttpFunc<'a, 'b> = Context<'a> -> Task<Context<'b>>
+type HttpFuncResult<'b> =  Task<Result<Context<'b>, ResponseError>>
+type HttpFunc<'a, 'b> = Context<'a> -> HttpFuncResult<'b>
 
 type NextFunc<'a, 'b> = HttpFunc<'a, 'b>
 
-type HttpHandler<'a, 'b, 'c> = NextFunc<'b, 'c> -> Context<'a> -> Task<Context<'c>>
+type HttpHandler<'a, 'b, 'c> = NextFunc<'b, 'c> -> Context<'a> -> HttpFuncResult<'c>
 
 type HttpHandler<'a, 'b> = HttpHandler<'a, 'a, 'b>
 
@@ -20,17 +21,18 @@ type HttpHandler = HttpHandler<HttpResponseMessage>
 
 [<AutoOpen>]
 module Handler =
+    let finishEarly<'a> : HttpFunc<'a, 'a> = Ok >> Task.FromResult
 
     /// Run the handler with the given context.
     let runHandler (handler: HttpHandler<'a,'b,'b>) (ctx : Context<'a>) : Task<Result<'b, ResponseError>> =
         task {
-            let! a = handler Task.FromResult ctx
-            return a.Result
+            let! result = handler finishEarly ctx
+            match result with
+            | Ok a -> return Ok a.Response
+            | Error err -> return Error err
         }
-    let map (mapper: 'a -> 'b) (next : NextFunc<'b,'c>) (ctx : Context<'a>) : Task<Context<'c>> =
-        match ctx.Result with
-        | Ok value -> next { Request = ctx.Request; Result = Ok (mapper value) }
-        | Error ex -> Task.FromResult { Request = ctx.Request; Result = Error ex }
+    let map (mapper: 'a -> 'b) (next : NextFunc<'b,'c>) (ctx : Context<'a>) : Task<Result<Context<'c>, ResponseError>> =
+        next { Request = ctx.Request; Response = (mapper ctx.Response) }
 
     let compose (first : HttpHandler<'a, 'b, 'd>) (second : HttpHandler<'b, 'c, 'd>) : HttpHandler<'a,'c,'d> =
         fun (next: NextFunc<_, _>) (ctx : Context<'a>) ->
@@ -44,60 +46,43 @@ module Handler =
     let (>=>) a b =
         compose a b
 
-    // https://fsharpforfunandprofit.com/posts/elevated-world-4/
-    let traverseContext fn (list : Context<'a> list) =
-        // define the monadic functions
-        let (>>=) ctx fn = Context.bind fn ctx
-
-        let retn a =
-            { Request = Context.defaultRequest; Result = Ok a }
-
-        // define a "cons" function
-        let cons head tail = head :: tail
-
-        // right fold over the list
-        let initState = retn []
-        let folder head tail =
-            fn head >>= (fun h ->
-                tail >>= (fun t ->
-                    retn (cons h t)
-                )
-            )
-
-        List.foldBack folder list initState
-
-    let sequenceContext (ctx : Context<'a> list) : Context<'a list> = traverseContext id ctx
-
     /// Run list of HTTP handlers concurrently.
-    let concurrent (handlers : HttpHandler<'a, 'b, 'b> seq) (next: NextFunc<'b list, 'c>) (ctx: Context<'a>) : Task<Context<'c>> = task {
+    let concurrent (handlers : HttpHandler<'a, 'b, 'b> seq) (next: NextFunc<'b list, 'c>) (ctx: Context<'a>) : HttpFuncResult<'c> = task {
         let! res =
             handlers
-            |> Seq.map (fun handler -> handler Task.FromResult ctx)
+            |> Seq.map (fun handler -> handler finishEarly ctx)
             |> Task.WhenAll
 
-        return! next (res |> List.ofArray |> sequenceContext)
+        let result = res |> List.ofArray |> Result.sequenceList
+        match result with
+        | Ok results ->
+            let bs = { Request = ctx.Request; Response = results |> List.map (fun r -> r.Response) }
+            return! next bs
+        | Error err -> return Error err
     }
 
     /// Run list of HTTP handlers sequentially.
-    let sequential (handlers : HttpHandler<'a, 'b, 'b> seq) (next: NextFunc<'b list, 'c>) (ctx: Context<'a>) : Task<Context<'c>> = task {
-        let res = ResizeArray<Context<'b>>()
+    let sequential (handlers : HttpHandler<'a, 'b, 'b> seq) (next: NextFunc<'b list, 'c>) (ctx: Context<'a>) : HttpFuncResult<'c> = task {
+        let res = ResizeArray<Result<Context<'b>, ResponseError>>()
 
         for handler in handlers do
-            let! result = handler Task.FromResult ctx
+            let! result = handler finishEarly ctx
             res.Add result
 
-        return! next (res |> List.ofSeq |> sequenceContext)
+        let result = res |> List.ofSeq |> Result.sequenceList
+        match result with
+        | Ok results ->
+            let bs = { Request = ctx.Request; Response = results |> List.map (fun c -> c.Response) }
+            return! next bs
+        | Error err -> return Error err
     }
 
     let extractHeader (header: string) (next: NextFunc<_,_>) (context: HttpContext) = task {
-        match context.Result with
-        | Ok response ->
-            let (success, values) = response.Headers.TryGetValues header
-            let values = if (isNull values) then [] else values |> List.ofSeq
-            match (success, values ) with
-            | (true, value :: _) ->
-                return! next { Request = context.Request; Result = Ok value }
-            | _ ->
-                return { Request = context.Request; Result = Error { ResponseError.empty with Message = sprintf "Missing header: %s" header }}
-        | Error error -> return { Request = context.Request; Result = Error error }
+        let (success, values) = context.Response.Headers.TryGetValues header
+        let values = if (isNull values) then [] else values |> List.ofSeq
+        match (success, values ) with
+        | (true, value :: _) ->
+            return! next { Request = context.Request; Response = Ok value }
+        | _ ->
+            return Error { ResponseError.empty with Message = sprintf "Missing header: %s" header }
     }

--- a/src/Oryx.fsproj
+++ b/src/Oryx.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="Error.fs" />
     <Compile Include="Context.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="Handler.fs" />
     <Compile Include="Fetch.fs" />
     <Compile Include="Retry.fs" />

--- a/src/Result.fs
+++ b/src/Result.fs
@@ -1,0 +1,20 @@
+// Copyright 2019 Cognite AS
+
+namespace Oryx
+
+[<RequireQualifiedAccess>]
+module Result =
+    let isOk = function
+        | Ok _ -> true
+        | _ -> false
+
+    let isError res = not (isOk res)
+
+    let (>>=) r f = Result.bind f r
+    let rtn v = Ok v
+
+    let traverseList f ls =
+        let folder head tail = f head >>= (fun h -> tail >>= (fun t -> h::t |> rtn))
+        List.foldBack folder ls (rtn List.empty)
+    let sequenceList ls = traverseList id ls
+

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -24,6 +24,6 @@ let unit (value: 'a) (next: NextFunc<'a, 'b>) (context: HttpContext) : Task<Resu
 let add (a: int) (b: int) (next: NextFunc<int, 'b>) (context: HttpContext) : Task<Result<Context<'b>, ResponseError>>  =
     unit (a + b) next context
 
-let error msg (next: NextFunc<'a, 'b>) (context: Context<'a>) : Task<Result<Context<'b>, ResponseError>> =
+let error msg (next: NextFunc<'b, 'c>) (_: Context<'a>) : Task<Result<Context<'c>, ResponseError>> =
     Error { ResponseError.empty with Message=msg } |> Task.FromResult
 

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -6,6 +6,7 @@ open System.Threading
 open System.Threading.Tasks
 
 open FSharp.Control.Tasks.V2
+open Thoth.Json.Net
 
 open Oryx
 
@@ -27,3 +28,10 @@ let add (a: int) (b: int) (next: NextFunc<int, 'b>) (context: HttpContext) : Tas
 let error msg (next: NextFunc<'b, 'c>) (_: Context<'a>) : Task<Result<Context<'c>, ResponseError>> =
     Error { ResponseError.empty with Message=msg } |> Task.FromResult
 
+let get () =
+    let decoder : Decoder<_> = Decode.object (fun get -> {| Value = get.Required.Field "value" Decode.int |})
+    let decodeResponse = Decode.decodeResponse decoder id
+
+    GET
+    >=> fetch
+    >=> decodeResponse

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -1,0 +1,132 @@
+module Tests.Fetch
+
+open System.Threading.Tasks
+
+open FSharp.Control.Tasks.V2
+open Swensen.Unquote
+open Xunit
+open FsCheck.Xunit
+open FsCheck
+open FsCheck.Arb
+
+
+open Oryx
+open Tests.Common
+open System
+open System.Net.Http
+open System.Threading
+open System.Net
+open Oryx.Retry
+
+[<Fact>]
+let ``Get asset with fusion return expression is Ok``() = task {
+    // Arrange
+    let mutable retries = 0
+    let json = """{ "value": 42}"""
+
+    let stub =
+        Func<HttpRequestMessage,CancellationToken,Task<HttpResponseMessage>>(fun request token ->
+        (task {
+            retries <- retries + 1
+            let responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            responseMessage.Content <- new StringContent(json)
+            return responseMessage
+        }))
+
+    let client = new HttpClient(new HttpMessageHandlerStub(stub))
+
+    let ctx =
+        Context.defaultContext
+        |> Context.setHttpClient client
+        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.addHeader ("api-key", "test-key")
+
+    // Act
+    let req = oryx {
+        let! result = get ()
+        return result
+    }
+
+    let! result = runHandler req ctx
+    let retries' = retries
+
+    // Assert
+    test <@ Result.isOk result @>
+    test <@ retries' = 1 @>
+}
+
+[<Fact>]
+let ``Fetch with retry is Ok``() = task {
+    // Arrange
+    let mutable retries = 0
+    let json = """{ "value": 42}"""
+
+    let stub =
+        Func<HttpRequestMessage,CancellationToken,Task<HttpResponseMessage>>(fun request token ->
+        (task {
+            retries <- retries + 1
+            let responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            responseMessage.Content <- new StringContent(json)
+            return responseMessage
+        }))
+
+    let client = new HttpClient(new HttpMessageHandlerStub(stub))
+
+    let ctx =
+        Context.defaultContext
+        |> Context.setHttpClient client
+        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.addHeader ("api-key", "test-key")
+
+    // Act
+    let req =
+        oryx {
+            let! result = get ()
+            return result
+        } |> retry shouldRetry 0<ms> 5
+
+    let! result = runHandler req ctx
+    let retries' = retries
+
+    // Assert
+    test <@ Result.isOk result @>
+    test <@ retries' = 1 @>
+}
+
+[<Fact>]
+let ``Fetch with retry on internal error will retry``() = task {
+    // Arrange
+    let mutable retries = 0
+    let json = """{ "error": { "code": 500, "message": "failed" }}"""
+
+    let stub =
+        Func<HttpRequestMessage,CancellationToken,Task<HttpResponseMessage>>(fun request token ->
+        (task {
+            retries <- retries + 1
+            let responseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            responseMessage.Content <- new StringContent(json)
+            return responseMessage
+        }))
+
+    let client = new HttpClient(new HttpMessageHandlerStub(stub))
+
+    let ctx =
+        Context.defaultContext
+        |> Context.setHttpClient client
+        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.addHeader ("api-key", "test-key")
+
+    // Act
+    let req =
+        oryx {
+            let! result = get ()
+            return result
+        } |> retry shouldRetry 0<ms> 5
+
+    let! result = runHandler req ctx
+    let retries' = retries
+
+    // Assert
+    test <@ Result.isError result @>
+    test <@ retries' = 6 @>
+}

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -19,13 +19,12 @@ let ``Simple unit handler is Ok``() = task {
     let ctx = Context.defaultContext
 
     // Act
-    let! ctx' = unit 42 Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = unit 42 finishEarly ctx
 
     // Assert
     test <@ Result.isOk result @>
     match result with
-    | Ok value -> test <@ value = 42 @>
+    | Ok ctx -> test <@ ctx.Response = 42 @>
     | Error err -> failwith err.Message
 }
 
@@ -35,8 +34,7 @@ let ``Simple error handler is Error``() = task {
     let ctx = Context.defaultContext
 
     // Act
-    let! ctx' = error "failed" Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = error "failed" finishEarly ctx
 
     // Assert
     test <@ Result.isError result @>
@@ -52,8 +50,7 @@ let ``Simple error then ok is Error``() = task {
     let req = error "failed" >=> unit 42
 
     // Act
-    let! ctx' = req Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = req finishEarly ctx
 
     // Assert
     test <@ Result.isError result @>
@@ -69,8 +66,7 @@ let ``Simple ok then error is Error``() = task {
     let req = unit 42 >=> error "failed"
 
     // Act
-    let! ctx' = req Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = req finishEarly ctx
 
     // Assert
     test <@ Result.isError result @>
@@ -92,13 +88,12 @@ let ``Sequential handlers is Ok``() = task {
     ]
 
     // Act
-    let! ctx' = req Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = req finishEarly ctx
 
     // Assert
     test <@ Result.isOk result @>
     match result with
-    | Ok value -> test <@ value = [1; 2; 3; 4; 5] @>
+    | Ok ctx -> test <@ ctx.Response = [1; 2; 3; 4; 5] @>
     | Error err -> failwith "error"
 }
 
@@ -115,13 +110,12 @@ let ``Concurrent handlers is Ok``() = task {
     ]
 
     // Act
-    let! ctx' = req Task.FromResult ctx
-    let result = ctx'.Result
+    let! result = req finishEarly ctx
 
     // Assert
     test <@ Result.isOk result @>
     match result with
-    | Ok value -> test <@ value = [1; 2; 3; 4; 5] @>
+    | Ok ctx -> test <@ ctx.Response = [1; 2; 3; 4; 5] @>
     | Error err -> failwith "error"
 }
 
@@ -133,12 +127,11 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
         let req = Chunk.chunk chunkSize maxConcurrency unit [1; 2; 3; 4; 5]
 
         // Act
-        let! ctx' = req Task.FromResult ctx
-        let result = ctx'.Result
+        let! result = req finishEarly ctx
 
         // Assert
         test <@ Result.isOk result @>
         match result with
-        | Ok value -> test <@ Seq.toList value = [ 1; 2; 3; 4; 5 ] @>
+        | Ok ctx -> test <@ Seq.toList ctx.Response = [ 1; 2; 3; 4; 5 ] @>
         | Error err -> failwith "error"
     } |> fun x -> x.Result

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -98,6 +98,28 @@ let ``Sequential handlers is Ok``() = task {
 }
 
 [<Fact>]
+let ``Sequential handlers with an Error is Error``() = task {
+    // Arrange
+    let ctx = Context.defaultContext
+    let req = sequential [
+            unit 1
+            unit 2
+            error "fail"
+            unit 4
+            unit 5
+    ]
+
+    // Act
+    let! result = req finishEarly ctx
+
+    // Assert
+    test <@ Result.isError result @>
+    match result with
+    | Ok _ -> failwith "expected failure"
+    | Error err -> test <@ err.Message = "fail" @>
+}
+
+[<Fact>]
 let ``Concurrent handlers is Ok``() = task {
     // Arrange
     let ctx = Context.defaultContext
@@ -117,6 +139,28 @@ let ``Concurrent handlers is Ok``() = task {
     match result with
     | Ok ctx -> test <@ ctx.Response = [1; 2; 3; 4; 5] @>
     | Error err -> failwith "error"
+}
+
+[<Fact>]
+let ``Concurrent handlers with an Error is Error``() = task {
+    // Arrange
+    let ctx = Context.defaultContext
+    let req = concurrent [
+            unit 1
+            unit 2
+            error "fail"
+            unit 4
+            unit 5
+    ]
+
+    // Act
+    let! result = req finishEarly ctx
+
+    // Assert
+    test <@ Result.isError result @>
+    match result with
+    | Ok _ -> failwith "expected failure"
+    | Error err -> test <@ err.Message = "fail" @>
 }
 
 [<Property>]

--- a/test/Tests.fsproj
+++ b/test/Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Context.fs" />
     <Compile Include="Handler.fs" />
     <Compile Include="Builder.fs" />
+    <Compile Include="Fetch.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
This makes it impossible to pass errors further down the pipeline, i.e use the type system to avoid programming mistakes.