### PR TITLE
Update docs and error handling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "5.233.0",
+      "version": "5.236.0",
       "commands": [
         "paket"
       ]

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ type Context<'a> = {
 The `Context` may be transformed by series of HTTP handlers. The `HttpHandler` takes a `Context` (and a `NextFunc`) and returns a new `Context` wrapped in a `Result` and `Task`.
 
 ```fs
-type HttpFuncResult<'b> =  Task<Result<Context<'b>, ResponseError>>
+type HttpFuncResult<'r, 'err> =  Task<Result<Context<'r>, HandlerError<'err>>>
 
-type HttpFunc<'a, 'b> = Context<'a> -> HttpFuncResult<'b>
-type NextFunc<'a, 'b> = HttpFunc<'a, 'b>
+type HttpFunc<'a, 'r, 'err> = Context<'a> -> HttpFuncResult<'r, 'err>
+type NextFunc<'a, 'r, 'err> = HttpFunc<'a, 'r, 'err>
 
-type HttpHandler<'a, 'b, 'c> = NextFunc<'b, 'c> -> Context<'a> -> HttpFuncResult<'c>
+type HttpHandler<'a, 'b, 'r, 'err> = NextFunc<'b, 'r, 'err> -> Context<'a> -> HttpFuncResult<'r, 'err>
 
 // For convenience
-type HttpHandler<'a, 'b> = HttpHandler<'a, 'a, 'b>
-type HttpHandler<'a> = HttpHandler<HttpResponseMessage, 'a>
-type HttpHandler = HttpHandler<HttpResponseMessage>
+type HttpHandler<'a, 'r, 'err> = HttpHandler<'a, 'a, 'r, 'err>
+type HttpHandler<'r, 'err> = HttpHandler<HttpResponseMessage, 'r, 'err>
+type HttpHandler<'err> = HttpHandler<HttpResponseMessage, 'err>
 ```
 
 An `HttpHandler` is a plain function that takes two curried arguments, a `NextFunc` and a `Context`, and returns a new `Context` (wrapped in a `Result` and `Task`) when finished. On a high level the `HttpHandler` function takes and returns a context object, which means every `HttpHandler` function has full control of the outgoing `HttpRequest` and also the resulting response.
@@ -62,21 +62,23 @@ let (>=>) a b = compose a b
 The `compose` function is the magic that sews it all togheter and explains how you can curry the `HttpHandler` to generate a new `NextFunc` that you give to next `HttpHandler`. If the first handler fails, the next handler will be skipped.
 
 ```fs
-let compose (first : HttpHandler<'a, 'b, 'd>) (second : HttpHandler<'b, 'c, 'd>) : HttpHandler<'a,'c,'d> =
-    fun (next: NextFunc<_, _>) (ctx : Context<'a>) ->
-        let func =
-            next
-            |> second
-            |> first
+    let compose (first : HttpHandler<'a, 'b, 'r, 'err>) (second : HttpHandler<'b, 'c, 'r, 'err>) : HttpHandler<'a,'c,'r, 'err> =
+        fun (next: NextFunc<'c, 'r, 'err>) (ctx : Context<'a>) ->
+            let func =
+                next
+                |> second
+                |> first
 
-        func ctx
+            func ctx
+
+    let (>=>) a b =
+        compose a b
 ```
 
 This enables you to compose your web requests and decode the response, e.g as we do when listing Assets in the  the [Cognite Data Fusion SDK](https://github.com/cognitedata/cognite-sdk-dotnet/blob/master/src/assets/ListAssets.fs#L55):
 
 ```fs
-    let listAssets (options: AssetQuery seq) (filters: AssetFilter seq) (fetch: HttpHandler<HttpResponseMessage, 'a>) =
-        let decodeResponse = Decode.decodeContent AssetItemsReadDto.Decoder id
+    let listCore (options: AssetQuery seq) (filters: AssetFilter seq) (fetch: HttpHandler<HttpResponseMessage, 'a>) =
         let request : Request = {
             Filters = filters
             Options = options
@@ -87,8 +89,8 @@ This enables you to compose your web requests and decode the response, e.g as we
         >=> setContent (Content.JsonValue request.Encoder)
         >=> setResource Url
         >=> fetch
-        >=> Decode.decodeError
-        >=> decodeResponse
+        >=> withError decodeError
+        >=> json AssetItemsReadDto.Decoder
 ```
 
 Thus the function `listAssets` is now also an `HttpHandler` and may be composed with other handlers to create complex chains for doing series of multiple requests to a web service.
@@ -113,7 +115,7 @@ Both encode and decode uses streaming so no large strings or arrays will be allo
 
 ## Computational Expression Builder
 
-Working with `Context` objects can be a bit painful since the actual result will be available inside a `Task` effect that has a `Result` that can be either `Ok` with the response or `Error`. To make it simpler to handle multiple requests using handlers you can use the `oryx` builder that will hide the complexity of both the `Context` and the `Result`.
+Working with `Context` objects can be a bit painful since the actual result will be available inside a `Task` effect that has a `Result` that can be either `Ok` of the actual response, or `Error`. To make it simpler to handle multiple requests using handlers you can use the `oryx` builder that will hide the complexity of both the `Context` and the `Result`.
 
 ```fs
     oryx {
@@ -124,19 +126,15 @@ Working with `Context` objects can be a bit painful since the actual result will
     }
 ```
 
-To run a handler u can use the `runHandler` function.
+To run a handler you can use the `runHandler` function.
 
 ```fs
-
-val runHandler : (handler: HttpHandler<'a,'b,'b>) -> (ctx : Context<'a>) -> Task<Result<'b, ResponseError>>
-
+let runHandler (handler: HttpHandler<'a,'r,'r, 'err>) (ctx : Context<'a>) : Task<Result<'r, HandlerError<'err>>>
 ```
 
 ## TODO
 
-- The library currently depends on [`Thoth.Json.Net`](https://mangelmaxime.github.io/Thoth/). This should at some point be split into a separate library.
-
-- The library also assumes the type of the error response. This should perhaps be made more generic.
+- The library currently depends on [`Thoth.Json.Net`](https://github.com/thoth-org/Thoth.Json.Net). This should at some point be split into a separate library.
 
 ## Code of Conduct
 

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -52,6 +52,8 @@ module Decoders =
             return Decode.fromValue "$" decoder json
         }
 
+module ResponseReaders =
+
     /// <summary>
     /// JSON decode response and map decode error string to exception so we don't get more response error types.
     /// </summary>

--- a/src/Error.fs
+++ b/src/Error.fs
@@ -5,8 +5,8 @@ namespace Oryx
 exception JsonDecodeException of string
 
 type HandlerError<'err> =
-    /// Request failed with an exception.
+    /// Request failed with some exception, e.g HttpClient throws an exception, or JSON decode error.
     | Panic of exn
-    /// User defined error type.
-    | ApiError of 'err
+    /// User defined error response.
+    | ResponseError of 'err
 

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -100,6 +100,5 @@ module Fetch =
                 use! response = client.SendAsync(message, cancellationToken)
                 return! next { ctx with Response = response }
             with
-            | ex ->
-                return Panic ex |> Error
+            | ex -> return Panic ex |> Error
         }

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -108,15 +108,15 @@ module Handler =
         return! next { Request = context.Request; Response = Ok values }
     }
 
-    /// A catch handler for catching errors and then delegating to the error handler on what to do.
-    let catch (errorHandler: HandlerError<'err> -> NextFunc<'a, 'r, 'err>) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) = task {
+    /// Catch handler for catching errors and then delegating to the error handler on what to do.
+    let catch (errorHandler: HandlerError<'err> -> NextFunc<'a, 'r, 'err>) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> = task {
         let! result = next ctx
         match result with
         | Ok ctx -> return Ok ctx
         | Error err -> return! errorHandler err ctx
     }
 
-    /// A error handler for decoding fetch responses. Will ignore successful responses.
+    /// Error handler for decoding fetch responses into an user defined error type. Will ignore successful responses.
     let withError<'a, 'r, 'err> (errorHandler : HttpResponseMessage -> Task<HandlerError<'err>>) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) : HttpFuncResult<'r, 'err> =
         task {
             let response = context.Response

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -23,11 +23,7 @@ type HttpHandler<'err> = HttpHandler<HttpResponseMessage, 'err>
 
 [<AutoOpen>]
 module Handler =
-    let iterate1 (f : unit -> seq<int>) =
-        for e in f() do printfn "%d" e
-    let iterate2 (f : unit -> #seq<int>) =
-        for e in f() do printfn "%d" e
-
+    /// A next continuation that produces an Ok async result. Used to end the processing pipeline.
     let finishEarly<'a, 'err> : HttpFunc<'a, 'a, 'err> = Ok >> Task.FromResult
 
     /// Run the HTTP handler in the given context.

--- a/test/Builder.fs
+++ b/test/Builder.fs
@@ -44,7 +44,7 @@ let ``Simple unit handler in builder is Ok``() = task {
     match result with
     | Ok value -> test <@ value = 42 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -66,7 +66,7 @@ let ``Simple return from unit handler in builder is Ok``() = task {
     match result with
     | Ok value -> test <@ value = 42 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -88,5 +88,5 @@ let ``Multiple handlers in builder is Ok``() = task {
     match result with
     | Ok value -> test <@ value = 30 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -9,6 +9,7 @@ open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Oryx
+open Oryx.ResponseReaders
 open System.Net
 
 type HttpMessageHandlerStub (sendAsync: Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>) =

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -78,9 +78,9 @@ let ``Fetch with retry is Ok``() = task {
     // Act
     let req =
         oryx {
-            let! result = get ()
+            let! result = retry >=> get ()
             return result
-        } |> retry shouldRetry 0<ms> 5
+        }
 
     let! result = runHandler req ctx
     let retries' = retries
@@ -116,9 +116,9 @@ let ``Fetch with retry on internal error will retry``() = task {
     // Act
     let req =
         oryx {
-            let! result = get ()
+            let! result = retry >=> get ()
             return result
-        } |> retry shouldRetry 0<ms> 5
+        }
 
     let! result = runHandler req ctx
     let retries' = retries

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -26,7 +26,7 @@ let ``Simple unit handler is Ok``() = task {
     match result with
     | Ok ctx -> test <@ ctx.Response = 42 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -42,7 +42,7 @@ let ``Simple error handler is Error``() = task {
     match result with
     | Ok _ -> failwith "error"
     | Error (Panic err) -> test <@ err.ToString() = "failed" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -59,7 +59,7 @@ let ``Simple error then ok is Error``() = task {
     match result with
     | Ok _ -> failwith "error"
     | Error (Panic err) -> test <@ err.ToString() = "failed" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -75,7 +75,7 @@ let ``Simple ok then error is Error``() = task {
     match result with
     | Ok _ -> failwith "error"
     | Error (Panic err) -> test <@ err.ToString () = "failed" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -92,7 +92,7 @@ let ``Catching ok is Ok``() = task {
     match result with
     | Ok ctx -> test <@ ctx.Response = 420 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -109,7 +109,7 @@ let ``Catching errors is Ok``() = task {
     match result with
     | Ok ctx -> test <@ ctx.Response = 420 @>
     | Error (Panic err) -> raise err
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -126,7 +126,7 @@ let ``Not catching errors is Error``() = task {
     match result with
     | Ok _ -> failwith "error"
     | Error (Panic err) -> test <@ err.ToString () = "failed" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -171,7 +171,7 @@ let ``Sequential handlers with an Error is Error``() = task {
     match result with
     | Ok _ -> failwith "expected failure"
     | Error (Panic err) -> test <@ err.ToString () = "fail" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Fact>]
@@ -216,7 +216,7 @@ let ``Concurrent handlers with an Error is Error``() = task {
     match result with
     | Ok _ -> failwith "expected failure"
     | Error (Panic err) -> test <@ err.ToString () = "fail" @>
-    | Error (ApiError err) -> failwith (err.ToString())
+    | Error (ResponseError err) -> failwith (err.ToString())
 }
 
 [<Property>]


### PR DESCRIPTION
- Put response readers in module to avoid collision with Giraffe
- Retry is now a proper HTTP handler. Thus you need to use it before the handler you want to retry.
- Renamed user supplied error to `ResponseError`.
- Some cleanup.