### PR TITLE
Simplify compose

### DIFF
--- a/test/Builder.fs
+++ b/test/Builder.fs
@@ -20,7 +20,7 @@ let ``Zero builder is Ok``() = task {
         ()
     }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -37,7 +37,7 @@ let ``Simple unit handler in builder is Ok``() = task {
         return value
     }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -59,7 +59,7 @@ let ``Simple return from unit handler in builder is Ok``() = task {
         return! unit 42
     }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -81,7 +81,7 @@ let ``Multiple handlers in builder is Ok``() = task {
         return! add a b
     }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
 
     // Assert
     test <@ Result.isOk result @>

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -44,7 +44,7 @@ let ``Get asset with fusion return expression is Ok``() = task {
         return result
     }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
     let retries' = retries
 
     // Assert
@@ -82,7 +82,7 @@ let ``Fetch with retry is Ok``() = task {
             return result
         }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
     let retries' = retries
 
     // Assert
@@ -120,7 +120,7 @@ let ``Fetch with retry on internal error will retry``() = task {
             return result
         }
 
-    let! result = runHandler req ctx
+    let! result = runAsync req ctx
     let retries' = retries
 
     // Assert


### PR DESCRIPTION
- Remove inner function from compose and replace with function composition.
- Make `>=>` and alias for `compose` instead of being its own function
- Rename `runHandler` to `runAsync` which is a better description since it's inside the `Handler` module. `Handler.runHandler` is a bit too much.