### PR TITLE
Benchmark Json serialization. 25X potential speedup.

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,15 +27,9 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -136,7 +130,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +163,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/benchmark/Common.fs
+++ b/benchmark/Common.fs
@@ -4,12 +4,16 @@ open System
 open System.Net.Http
 open System.Threading
 open System.Threading.Tasks
-
+open System.Text
+open System.Text.Json.Serialization
 open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
+open Utf8Json
 
 open Oryx
 open Oryx.ResponseReaders
+open System.IO
+open Newtonsoft.Json
 
 type TestError = {
     Code : int
@@ -30,6 +34,11 @@ type TestType = {
     Value: int
 }
 
+type TestType2 (name: string, value: int) =
+    member this.Name = name
+    member this.Value = value
+    new () = TestType2("", 0)
+
 let decodeError (response: HttpResponseMessage) : Task<HandlerError<TestError>> = task {
     let! stream = response.Content.ReadAsStreamAsync ()
     let decoder = Decode.object (fun get ->
@@ -48,6 +57,7 @@ let decoder : Decoder<TestType> =
         Name = get.Required.Field "name" Decode.string
         Value = get.Required.Field "value" Decode.int
     })
+let listDecoder = Decode.list decoder
 
 let noop (next: NextFunc<int, int, 'err>) (ctx: Context<'a>) : HttpFuncResult<int, 'err> =
     task {
@@ -63,3 +73,63 @@ let get () =
     >=> json decoder
     >=> noop
     >=> noop
+
+let getList () =
+
+    GET
+    >=> setUrl "http://test"
+    >=> fetch
+    >=> withError decodeError
+    >=> json listDecoder
+
+let readUtf8<'a> stream =
+    try
+        task {
+            let! a = (JsonSerializer.DeserializeAsync<'a> stream)
+            return Ok a
+        }
+    with
+    e -> task { return Error (e.ToString()) }
+
+let readJson<'a> stream =
+    let mutable options = Json.JsonSerializerOptions()
+    options.AllowTrailingCommas <- true
+    try
+        task {
+            let! a = (Json.JsonSerializer.DeserializeAsync<'a>(stream, options)).AsTask()
+            return Ok a
+        }
+    with
+    e -> task { return Error (e.ToString()) }
+
+let readNewtonsoft<'a> (stream: IO.Stream) =
+    let serializer = JsonSerializer()
+    use tr = new StreamReader(stream) // StreamReader will dispose the stream
+    use jtr = new JsonTextReader(tr, DateParseHandling = DateParseHandling.None)
+
+    try
+        task {
+            let a = (serializer.Deserialize<'a> jtr)
+            return Ok a
+        }
+    with
+    e -> task { return Error (e.ToString()) }
+
+let jsonReader<'a, 'r, 'err> (reader: Stream -> Task<Result<'a, string>>) (next: NextFunc<'a,'r, 'err>) (context: HttpContext) : HttpFuncResult<'r, 'err> =
+    task {
+        use! stream = context.Response.Content.ReadAsStreamAsync ()
+        let! ret = reader stream
+
+        match ret with
+        | Ok result ->
+            return! next { Request = context.Request; Response = result }
+        | Error error ->
+            return Error (Panic <| JsonDecodeException error)
+    }
+
+let get2 (reader: Stream -> Task<Result<ResizeArray<TestType2>, string>>) : HttpHandler<HttpResponseMessage, ResizeArray<TestType2>, 'b, TestError> =
+    GET
+    >=> setUrl "http://test"
+    >=> fetch
+    >=> withError decodeError
+    >=> jsonReader reader

--- a/benchmark/Program.fs
+++ b/benchmark/Program.fs
@@ -5,6 +5,7 @@ open BenchmarkDotNet.Attributes
 open BenchmarkDotNet.Running
 
 open Benchmark.Fetch
+open Benchmark.Json
 
 let add ((a, b) : int * int) = a + b
 
@@ -16,7 +17,7 @@ type OryxBenchmark () =
 
 [<EntryPoint>]
 let main argv =
-    let summary = BenchmarkRunner.Run typeof<FetchBenchmark>
+    let summary = BenchmarkRunner.Run typeof<JsonBenchmark>
     printfn "%A" summary
     0
 

--- a/benchmark/benchmark.fsproj
+++ b/benchmark/benchmark.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Classic.fs" />
     <Compile Include="ClassicPly.fs" />
     <Compile Include="Fetch.fs" />
+    <Compile Include="Json.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/benchmark/paket.references
+++ b/benchmark/paket.references
@@ -2,3 +2,4 @@ group Benchmark
 
 BenchmarkDotNet
 Ply
+Utf8Json

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -29,3 +29,4 @@ group Benchmark
 
     nuget BenchmarkDotNet
     nuget Ply
+    nuget Utf8Json

--- a/paket.lock
+++ b/paket.lock
@@ -112,10 +112,10 @@ NUGET
       System.Numerics.Vectors (>= 4.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     System.Numerics.Vectors (4.5) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< net46) (>= net461) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= netstandard2.0) (>= uap10.1))
-    System.Reflection.Emit (4.7) - restriction: >= netstandard2.0
+    System.Reflection.Emit (4.7) - restriction: || (>= net45) (>= netstandard2.0)
       System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
     System.Reflection.Emit.ILGeneration (4.7) - restriction: || (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1))
-    System.Reflection.Emit.Lightweight (4.7) - restriction: >= netstandard2.0
+    System.Reflection.Emit.Lightweight (4.7) - restriction: || (>= net45) (>= netstandard2.0)
       System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wp8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard2.0) (>= wpa81)) (&& (>= portable-net45+win8+wp8+wpa81) (< portable-net45+wp8) (< win8)) (&& (< portable-net45+wp8) (>= win8)) (>= uap10.1)
     System.Reflection.Metadata (1.8) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 1.7) - restriction: || (>= net45) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81))
@@ -129,9 +129,14 @@ NUGET
     System.Text.Encoding.CodePages (4.7) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.7) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp3.1))
-    System.Threading.Tasks.Extensions (4.5.3) - restriction: >= netstandard2.0
+    System.Threading.Tasks.Extensions (4.5.3) - restriction: || (>= net45) (>= netstandard2.0)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
-    System.ValueTuple (4.5) - restriction: >= netstandard2.0
+    System.ValueTuple (4.5) - restriction: || (>= net45) (>= netstandard2.0)
+    Utf8Json (1.3.7)
+      System.Reflection.Emit (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
+      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
+      System.Threading.Tasks.Extensions (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
+      System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
 
 GROUP Test
 STORAGE: NONE

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -59,8 +59,8 @@ module ResponseReaders =
     /// JSON decode response and map decode error string to exception so we don't get more response error types.
     /// </summary>
     /// <param name="decoder">Decoder to use. </param>
-    /// <param name="resultMapper">Mapper for transforming the result.</param>
     /// <param name="next">The next handler to use.</param>
+    /// <param name="context">HttpContext.</param>
     /// <returns>Decoded context.</returns>
     let json<'a, 'r, 'err> (decoder : Decoder<'a>) (next: NextFunc<'a,'r, 'err>) (context: HttpContext) : HttpFuncResult<'r, 'err> =
         task {


### PR DESCRIPTION
```
|           Method |      Mean |     Error |    StdDev | Ratio |     Gen 0 |     Gen 1 |    Gen 2 |   Allocated |
|----------------- |----------:|----------:|----------:|------:|----------:|----------:|---------:|------------:|
|             Toth | 59.415 ms | 1.2872 ms | 1.4823 ms |  1.00 | 4555.5556 | 2000.0000 | 777.7778 | 18447.61 KB |
|         Utf8Json |  2.534 ms | 0.0128 ms | 0.0147 ms |  0.04 |  410.1563 |  402.3438 | 332.0313 |  1776.21 KB |
| System.Text.Json |  6.637 ms | 0.0300 ms | 0.0345 ms |  0.11 |  187.5000 |  179.6875 | 125.0000 |   895.16 KB |```

Utf8Json is fastest by a large margin.
System.Text.Json has fewer memory allocations while being 2-3X slower.
Jil was not supported in .NET core 3.1.