### PR TITLE
Add fixes for performance.

### DIFF
--- a/benchmark/Classic.fs
+++ b/benchmark/Classic.fs
@@ -77,7 +77,7 @@ module ClassicHandler =
 
         task {
             try
-                let message = buildRequest client ctx
+                use message = buildRequest client ctx
                 let! response = client.SendAsync(message, cancellationToken)
                 return Ok { ctx with Response = response }
             with
@@ -86,9 +86,10 @@ module ClassicHandler =
 
     let json<'a, 'err> (decoder : Decoder<'a>) (context: HttpContext) : HttpFuncResultClassic<'a, 'err> =
         task {
-            let response = context.Response
-            use! stream = response.Content.ReadAsStreamAsync ()
+            use response = context.Response
+            let! stream = response.Content.ReadAsStreamAsync ()
             let! ret = decodeStreamAsync decoder stream
+            do! stream.DisposeAsync ()
             match ret with
             | Ok result ->
                 return Ok { Request = context.Request; Response = result }
@@ -96,20 +97,26 @@ module ClassicHandler =
                 return Error (Panic <| JsonDecodeException error)
         }
 
-    let get () =
-        let decoder : Decoder<TestType> =
-            Decode.object (fun get -> {
-                Name = get.Required.Field "name" Decode.string
-                Value = get.Required.Field "value" Decode.int
-            })
+    let decoder : Decoder<TestType> =
+        Decode.object (fun get -> {
+            Name = get.Required.Field "name" Decode.string
+            Value = get.Required.Field "value" Decode.int
+        })
 
+    let noop (ctx: Context<'a>) : HttpFuncResultClassic<int, 'err> =
+        let ctx' = { Request = ctx.Request; Response = 42 }
+        Ok ctx' |> Task.FromResult
+
+    let get () =
         GET
         >=> setUrl "http://test"
         >=> fetch
         >=> withError decodeError
         >=> json decoder
+        >=> noop
+        >=> noop
 
-type RequestBuilder () =
+ type RequestBuilder () =
     member this.Zero () : HttpHandlerClassic<HttpResponseMessage, _, 'err> =
         fun _ ->
             Ok Context.defaultContext |> Task.FromResult

--- a/benchmark/benchmark.fsproj
+++ b/benchmark/benchmark.fsproj
@@ -1,17 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="../src/Oryx.fsproj">
-      <Name>Oryx.fsproj</Name>
-    </ProjectReference>
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Common.fs" />
     <Compile Include="Classic.fs" />
@@ -19,5 +11,12 @@
     <Compile Include="Fetch.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../src/Oryx.fsproj">
+      <Name>Oryx.fsproj</Name>
+    </ProjectReference>
+  </ItemGroup>
+
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/benchmark/run
+++ b/benchmark/run
@@ -1,1 +1,0 @@
-sudo dotnet run -c release --runtimes netcoreapp3.1

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dotnet build -c Release
+sudo dotnet run build -c Release --runtimes netcoreapp3.1

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -65,7 +65,7 @@ module ResponseReaders =
     let json<'a, 'r, 'err> (decoder : Decoder<'a>) (next: NextFunc<'a,'r, 'err>) (context: HttpContext) : HttpFuncResult<'r, 'err> =
         task {
             let response = context.Response
-            use! stream = response.Content.ReadAsStreamAsync ()
+            let! stream = response.Content.ReadAsStreamAsync ()
             let! ret = decodeStreamAsync decoder stream
             match ret with
             | Ok result ->
@@ -77,11 +77,10 @@ module ResponseReaders =
     let protobuf<'b, 'r, 'err> (parser : Stream -> 'b) (next: NextFunc<'b, 'r, 'err>) (context : Context<HttpResponseMessage>) : Task<Result<Context<'r>,HandlerError<'err>>> =
         task {
             let response = context.Response
-            use! stream = response.Content.ReadAsStreamAsync ()
+            let! stream = response.Content.ReadAsStreamAsync ()
             try
                 let b = parser stream
                 return! next { Request = context.Request; Response = b }
-
             with
             | ex -> return Error (Panic ex)
         }

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -61,7 +61,7 @@ let shouldRetry (error: HandlerError<TestError>) : bool =
     | Panic _ -> false
 
 let decodeError (response: HttpResponseMessage) : Task<HandlerError<TestError>> = task {
-    use! stream = response.Content.ReadAsStreamAsync ()
+    let! stream = response.Content.ReadAsStreamAsync ()
     let decoder = Decode.object (fun get ->
         {
             Code = get.Required.Field "code" Decode.int


### PR DESCRIPTION
Stop using `use!`. Not needed anyways since next handlers will never throw and disposing `HttpResponseMessage` will also dispose the underlying content (stream).