### PR TITLE
Cleanup perf testing

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,9 +27,15 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-    
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# DotNet SDK -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -130,7 +136,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -163,7 +169,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-    
+
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/benchmark/Json.fs
+++ b/benchmark/Json.fs
@@ -64,7 +64,7 @@ type JsonBenchmark () =
     member self.FetchUtf8 () =
         (task {
             let req = oryx {
-                let! a = Common.get2 (readUtf8)
+                let! a = Common.getJson (readUtf8)
                 return a
             }
             let! res = runAsync req ctx
@@ -77,7 +77,7 @@ type JsonBenchmark () =
     member self.FetchJson () =
         (task {
             let req = oryx {
-                let! a = Common.get2 (readJson)
+                let! a = Common.getJson (readJson)
                 return a
             }
             let! res = runAsync req ctx
@@ -90,7 +90,7 @@ type JsonBenchmark () =
     member self.FetchNewtonsoft () =
         (task {
             let req = oryx {
-                let! a = Common.get2 (readNewtonsoft)
+                let! a = Common.getJson (readNewtonsoft)
                 return a
             }
             let! res = runAsync req ctx

--- a/benchmark/benchmark.fsproj
+++ b/benchmark/benchmark.fsproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <Compile Include="Common.fs" />
     <Compile Include="Classic.fs" />
-    <Compile Include="ClassicPly.fs" />
+    <Compile Include="Ply.fs" />
     <Compile Include="Fetch.fs" />
     <Compile Include="Json.fs" />
     <Compile Include="Program.fs" />

--- a/oryx.sln
+++ b/oryx.sln
@@ -7,6 +7,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Oryx", "src\Oryx.fsproj", "
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Tests", "test\Tests.fsproj", "{708710D0-07E1-4CDB-AB4C-B86E90A74426}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "benchmark", "benchmark\benchmark.fsproj", "{218FB8E8-EBE7-4B37-98A4-F455151073E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,17 @@ Global
 		{708710D0-07E1-4CDB-AB4C-B86E90A74426}.Release|x64.Build.0 = Release|Any CPU
 		{708710D0-07E1-4CDB-AB4C-B86E90A74426}.Release|x86.ActiveCfg = Release|Any CPU
 		{708710D0-07E1-4CDB-AB4C-B86E90A74426}.Release|x86.Build.0 = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|x64.Build.0 = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Debug|x86.Build.0 = Debug|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|x64.ActiveCfg = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|x64.Build.0 = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|x86.ActiveCfg = Release|Any CPU
+		{218FB8E8-EBE7-4B37-98A4-F455151073E0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Add benchmark project to solution file.
- Reuse test type for CLR.
- Use sequences instead of resize arrays.
- Simplify exception handling.