### PR TITLE
Swap arguments for runAsync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,16 @@ It turns out that we can simplify this even further using [η-conversion](https:
 This enables you to compose your web requests and decode the response, e.g as we do when listing Assets in the [Cognite Data Fusion SDK](https://github.com/cognitedata/cognite-sdk-dotnet/blob/master/src/assets/ListAssets.fs#L55):
 
 ```fs
-    let listCore (options: AssetQuery seq) (filters: AssetFilter seq) (fetch: HttpHandler<HttpResponseMessage, 'a>) =
-        let request : Request = {
-            Filters = filters
-            Options = options
-        }
+    let list (query: AssetQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<AssetReadDto>, 'a> =
+        let url = Url +/ "list"
 
         POST
         >=> setVersion V10
-        >=> setContent (Content.JsonValue request.Encoder)
-        >=> setResource Url
+        >=> setResource url
+        >=> setContent (new JsonPushStreamContent<AssetQuery>(query, jsonOptions))
         >=> fetch
         >=> withError decodeError
-        >=> json AssetItemsReadDto.Decoder
+        >=> json jsonOptions
 ```
 
 Thus the function `listAssets` is now also an `HttpHandler` and may be composed with other handlers to create complex chains for doing series of multiple requests to a web service.

--- a/benchmark/Fetch.fs
+++ b/benchmark/Fetch.fs
@@ -60,7 +60,7 @@ type FetchBenchmark () =
 
                 return b
             }
-            let! res = runAsync request ctx
+            let! res = request |> runAsync ctx
             match res with
             | Error e -> failwith <| sprintf "Got error: %A" (e.ToString ())
             | Ok data -> ()

--- a/benchmark/Json.fs
+++ b/benchmark/Json.fs
@@ -54,7 +54,7 @@ type JsonBenchmark () =
                 let! a = Common.getList ()
                 return a
             }
-            let! res = runAsync request ctx
+            let! res = request |> runAsync ctx
             match res with
             | Error e -> failwith <| sprintf "Got error: %A" (e.ToString ())
             | Ok data -> ()
@@ -67,7 +67,7 @@ type JsonBenchmark () =
                 let! a = Common.getJson (readUtf8)
                 return a
             }
-            let! res = runAsync request ctx
+            let! res = request |> runAsync ctx
             match res with
             | Error e -> failwith <| sprintf "Got error: %A" (e.ToString ())
             | Ok data -> ()
@@ -80,7 +80,7 @@ type JsonBenchmark () =
                 let! a = Common.getJson (readJson)
                 return a
             }
-            let! res = runAsync request ctx
+            let! res = request |> runAsync ctx
             match res with
             | Error e -> failwith <| sprintf "Got error: %A" (e.ToString ())
             | Ok data -> ()
@@ -93,7 +93,7 @@ type JsonBenchmark () =
                 let! a = Common.getJson (readNewtonsoft)
                 return a
             }
-            let! res = runAsync request ctx
+            let! res = request |> runAsync ctx
             match res with
             | Error e -> failwith <| sprintf "Got error: %A" (e.ToString ())
             | Ok data -> ()

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -28,7 +28,7 @@ and HttpRequest = {
     /// Content to be sent as body of the request.
     Content: HttpContent option
     /// Query parameters
-    Query: (string * string) list
+    Query: struct (string * string) seq
     /// Responsetype. JSON or Protobuf
     ResponseType: ResponseType
     /// List of headers to be sent

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -24,7 +24,7 @@ module Fetch =
         let query = ctx.Request.Query
         let url =
             let result = ctx.Request.UrlBuilder ctx.Request
-            if List.isEmpty query
+            if Seq.isEmpty query
             then result
             else
                 let queryString = HttpUtility.ParseQueryString(String.Empty)
@@ -62,7 +62,7 @@ module Fetch =
         task {
             try
                 use request = buildRequest client ctx
-                // Note we don't use `use!` here since the next handler will never throw exceptions. Thus we can
+                // Note: we don't use `use!` here since the next handler will never throw exceptions. Thus we can
                 // dispose ourselves which is much faster than using `use!`.
                 let! response = client.SendAsync(request, cancellationToken)
                 let! result = next { ctx with Response = response }

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -28,7 +28,7 @@ module Handler =
     let finishEarly<'a, 'err> : HttpFunc<'a, 'a, 'err> = Ok >> Task.FromResult
 
     /// Run the HTTP handler in the given context.
-    let runAsync (handler: HttpHandler<'a,'r,'r, 'err>) (ctx : Context<'a>) : Task<Result<'r, HandlerError<'err>>> =
+    let runAsync (ctx : Context<'a>) (handler: HttpHandler<'a,'r,'r, 'err>) : Task<Result<'r, HandlerError<'err>>> =
         task {
             let! result = handler finishEarly ctx
             match result with
@@ -45,7 +45,7 @@ module Handler =
 
     /// Add query parameters to context. These parameters will be added
     /// to the query string of requests that uses this context.
-    let addQuery (query: (string * string) list) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let addQuery (query: struct (string * string) seq) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Query = query } }
 
     /// Add content to context. These content will be added to the HTTP body of

--- a/test/Builder.fs
+++ b/test/Builder.fs
@@ -1,7 +1,5 @@
 module Tests.Builder
 
-open System.Threading.Tasks
-
 open FSharp.Control.Tasks.V2
 open Swensen.Unquote
 open Xunit
@@ -16,11 +14,7 @@ let ``Zero builder is Ok``() = task {
     let ctx = Context.defaultContext
 
     // Act
-    let request = req {
-        ()
-    }
-
-    let! result = runAsync request ctx
+    let! result = req { () } |> runAsync ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -32,12 +26,12 @@ let ``Simple unit handler in builder is Ok``() = task {
     let ctx = Context.defaultContext
 
     // Act
-    let request = req {
-        let! value = unit 42
-        return value
-    }
-
-    let! result = runAsync request ctx
+    let! result =
+        req {
+            let! value = unit 42
+            return value
+        }
+        |> runAsync ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -55,11 +49,9 @@ let ``Simple return from unit handler in builder is Ok``() = task {
     let a = unit 42 finishEarly
 
     // Act
-    let request = req {
-        return! unit 42
-    }
-
-    let! result = runAsync request ctx
+    let! result =
+        req { return! unit 42 }
+        |> runAsync ctx
 
     // Assert
     test <@ Result.isOk result @>
@@ -81,7 +73,7 @@ let ``Multiple handlers in builder is Ok``() = task {
         return! add a b
     }
 
-    let! result = runAsync request ctx
+    let! result = request |> runAsync ctx
 
     // Assert
     test <@ Result.isOk result @>

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -43,7 +43,7 @@ let ``Get with return expression is Ok``() = task {
         return result
     }
 
-    let! result = runAsync request ctx
+    let! result = request |> runAsync ctx
     let retries' = retries
 
     // Assert
@@ -84,7 +84,7 @@ let ``Post url encoded with return expression is Ok``() = task {
         return result
     }
 
-    let! result = runAsync request ctx
+    let! result = request |> runAsync ctx
     let urldecoded' = urlencoded
 
     // Assert
@@ -122,7 +122,7 @@ let ``Fetch with retry is Ok``() = task {
             return result
         }
 
-    let! result = runAsync request ctx
+    let! result = request |> runAsync ctx
     let retries' = retries
 
     // Assert
@@ -160,7 +160,7 @@ let ``Fetch with retry on internal error will retry``() = task {
             return result
         }
 
-    let! result = runAsync request ctx
+    let! result = request |> runAsync ctx
     let retries' = retries
 
     // Assert


### PR DESCRIPTION
- This enables easier currying since you can then pipe the handler into runAsync
- Make query parameters a struct tuple (ValueTuple) for better interop with C#.
- Update doc example.
- Update tests