### PR TITLE
Adjust the logger syntax

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -703,7 +703,7 @@ NUGET
     Fable.Core (3.1.4)
       FSharp.Core (>= 4.7)
     FSharp.Core (4.7)
-    Google.Protobuf (3.11.2)
+    Google.Protobuf (3.11.3)
       System.Memory (>= 4.5.2)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)
@@ -772,7 +772,7 @@ NUGET
     Fable.Core (3.1.4)
       FSharp.Core (>= 4.7)
     FSharp.Core (4.7)
-    Google.Protobuf (3.11.2)
+    Google.Protobuf (3.11.3)
       System.Memory (>= 4.5.2)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)
@@ -851,7 +851,7 @@ NUGET
     Fable.Core (3.1.4)
       FSharp.Core (>= 4.7)
     FSharp.Core (4.7)
-    Google.Protobuf (3.11.2)
+    Google.Protobuf (3.11.3)
       System.Memory (>= 4.5.2)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)
@@ -926,20 +926,20 @@ NUGET
       FsCheck (2.14)
       xunit.extensibility.execution (>= 2.2 < 3.0)
     FSharp.Core (4.7)
-    Microsoft.CodeCoverage (16.4) - restriction: || (>= net45) (>= netcoreapp2.1)
-    Microsoft.NET.Test.Sdk (16.4)
-      Microsoft.CodeCoverage (>= 16.4) - restriction: || (>= net45) (>= netcoreapp2.1)
-      Microsoft.TestPlatform.TestHost (>= 16.4) - restriction: >= netcoreapp2.1
+    Microsoft.CodeCoverage (16.5) - restriction: || (>= net45) (>= netcoreapp2.1)
+    Microsoft.NET.Test.Sdk (16.5)
+      Microsoft.CodeCoverage (>= 16.5) - restriction: || (>= net45) (>= netcoreapp2.1)
+      Microsoft.TestPlatform.TestHost (>= 16.5) - restriction: >= netcoreapp2.1
       Newtonsoft.Json (>= 9.0.1) - restriction: >= uap10.0
       System.ComponentModel.Primitives (>= 4.1) - restriction: >= uap10.0
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: >= uap10.0
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: >= uap10.0
     Microsoft.NETCore.Platforms (3.1) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.2) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard1.1) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (< netstandard1.2) (>= uap10.0) (< win8)) (&& (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.2) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (>= netstandard1.1) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (< netstandard1.2) (>= uap10.0) (< win8)) (&& (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< win81) (< wpa81))
-    Microsoft.TestPlatform.ObjectModel (16.4) - restriction: >= netcoreapp2.1
+    Microsoft.TestPlatform.ObjectModel (16.5) - restriction: >= netcoreapp2.1
       NuGet.Frameworks (>= 5.0) - restriction: || (>= net451) (>= netstandard2.0)
-    Microsoft.TestPlatform.TestHost (16.4) - restriction: >= netcoreapp2.1
-      Microsoft.TestPlatform.ObjectModel (>= 16.4) - restriction: || (>= netcoreapp2.1) (>= uap10.0)
+    Microsoft.TestPlatform.TestHost (16.5) - restriction: >= netcoreapp2.1
+      Microsoft.TestPlatform.ObjectModel (>= 16.5) - restriction: || (>= netcoreapp2.1) (>= uap10.0)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= netcoreapp2.1) (>= uap10.0)
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1511,7 +1511,7 @@ NUGET
     Fable.Core (3.1.4)
       FSharp.Core (>= 4.7)
     FSharp.Core (4.7)
-    Google.Protobuf (3.11.2)
+    Google.Protobuf (3.11.3)
       System.Memory (>= 4.5.2)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -46,7 +46,7 @@ and HttpRequest = {
     /// Optional Logger for logging requests.
     Logger: ILogger option
     /// The LogLevel to log at
-    LoggerLevel: LogLevel
+    LogLevel: LogLevel
     /// Optional Metrics for recording metrics.
     Metrics: IMetrics
     /// Extra info used to e.g build the URL. Clients are free to utilize this property for adding extra information to
@@ -82,7 +82,7 @@ module Context =
             UrlBuilder = fun _ -> String.Empty
             CancellationToken = None
             Logger = None
-            LoggerLevel = LogLevel.Debug
+            LogLevel = LogLevel.Debug
             Metrics = EmptyMetrics ()
             Extra = Map.empty
         }
@@ -117,8 +117,8 @@ module Context =
     let setLogger (logger: ILogger) (context: HttpContext) =
         { context with Request = { context.Request with Logger = Some logger } }
 
-    let setLoggerLevel (logLevel: LogLevel) (context: HttpContext) =
-        { context with Request = { context.Request with LoggerLevel = logLevel } }
+    let setLogLevel (logLevel: LogLevel) (context: HttpContext) =
+        { context with Request = { context.Request with LogLevel = logLevel } }
 
     let setMetrics (metrics: IMetrics) (context: HttpContext) =
         { context with Request = { context.Request with Metrics = metrics } }

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -279,7 +279,7 @@ let ``Get with logging request and response is OK``() = task {
         |> Context.setUrlBuilder (fun _ -> "http://test.org/")
         |> Context.addHeader ("api-key", "test-key")
         |> Context.setLogger(logger)
-        |> Context.setLoggerLevel LogLevel.Debug
+        |> Context.setLogLevel LogLevel.Debug
 
 
     // Act

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -11,6 +11,7 @@ open FsCheck.Arb
 
 
 open Oryx
+open Oryx.Chunk
 open Tests.Common
 
 [<Fact>]
@@ -224,7 +225,7 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
     task {
         // Arrange
         let ctx = Context.defaultContext
-        let req = Chunk.chunk chunkSize maxConcurrency unit [1; 2; 3; 4; 5]
+        let req = chunk chunkSize maxConcurrency unit [1; 2; 3; 4; 5]
 
         // Act
         let! result = req finishEarly ctx


### PR DESCRIPTION
Adjust the logger syntax
- Don't log content if null
- Rename `SetLoggerLevel` to `SetLogLevel`
- Update dependencies