### PR TITLE
Logging format

### DIFF
--- a/src/Context.fs
+++ b/src/Context.fs
@@ -72,7 +72,7 @@ module Context =
     let lazyContent content = Some <| fun () -> content
 
 
-    let defaultLogFormat = "Oryx: {Msg} {Method} {Uri} > \n{Content}{Response}"
+    let defaultLogFormat = "Oryx: {Message} {HttpMethod} {Uri} > \n{RequestContent}{ResponseContent}"
 
     /// Default context to use.
     let defaultRequest =

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -72,7 +72,7 @@ module Context =
     let lazyContent content = Some <| fun () -> content
 
 
-    let defaultLogFormat = "Oryx: {Method} {Uri} > \n{Content}{Response}"
+    let defaultLogFormat = "Oryx: {Msg} {Method} {Uri} > \n{Content}{Response}"
 
     /// Default context to use.
     let defaultRequest =

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -47,6 +47,8 @@ and HttpRequest = {
     Logger: ILogger option
     /// The LogLevel to log at
     LogLevel: LogLevel
+    /// Logging format string
+    LogFormat: string
     /// Optional Metrics for recording metrics.
     Metrics: IMetrics
     /// Extra info used to e.g build the URL. Clients are free to utilize this property for adding extra information to
@@ -69,6 +71,9 @@ module Context =
     /// Note that lazy content may not work with retry, logging etc where content may have been disposed.
     let lazyContent content = Some <| fun () -> content
 
+
+    let defaultLogFormat = "Oryx: {Method} {Uri} > \n{Content}{Response}"
+
     /// Default context to use.
     let defaultRequest =
         let ua = sprintf "Oryx / v%d.%d.%d (Cognite)" version.Major version.Minor version.Build
@@ -83,6 +88,7 @@ module Context =
             CancellationToken = None
             Logger = None
             LogLevel = LogLevel.None
+            LogFormat = defaultLogFormat
             Metrics = EmptyMetrics ()
             Extra = Map.empty
         }
@@ -118,6 +124,9 @@ module Context =
 
     let setLogLevel (logLevel: LogLevel) (context: HttpContext) =
         { context with Request = { context.Request with LogLevel = logLevel } }
+
+    let setLogFormat (format: string) (context: HttpContext) =
+        { context with Request = { context.Request with LogFormat = format } }
 
     let setMetrics (metrics: IMetrics) (context: HttpContext) =
         { context with Request = { context.Request with Metrics = metrics } }

--- a/src/Error.fs
+++ b/src/Error.fs
@@ -2,9 +2,30 @@
 
 namespace Oryx
 
-type HandlerError<'err> =
-    /// Request failed with some exception, e.g HttpClient throws an exception, or JSON decode error.
-    | Panic of exn
-    /// User defined error response.
-    | ResponseError of 'err
+open System.Net.Http
+open System.Threading.Tasks
+open FSharp.Control.Tasks.V2.ContextInsensitive
+
+[<AutoOpen>]
+module Error =
+    /// Catch handler for catching errors and then delegating to the error handler on what to do.
+    let catch (errorHandler: HandlerError<'err> -> NextFunc<'a, 'r, 'err>) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> = task {
+        let! result = next ctx
+        match result with
+        | Ok ctx -> return Ok ctx
+        | Error err -> return! errorHandler err ctx
+    }
+
+    /// Error handler for decoding fetch responses into an user defined error type. Will ignore successful responses.
+    let withError<'a, 'r, 'err> (errorHandler : HttpResponseMessage -> Task<HandlerError<'err>>) (next: NextFunc<HttpResponseMessage,'r, 'err>) (ctx: HttpContext) : HttpFuncResult<'r, 'err> =
+        task {
+            let response = ctx.Response
+            match response.IsSuccessStatusCode with
+            | true -> return! next ctx
+            | false ->
+                ctx.Request.Metrics.TraceFetchErrorInc 1L
+
+                let! err = errorHandler response
+                return err |> Error
+        }
 

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -20,8 +20,8 @@ module Logging =
     // Pre-compiled
     let private reqex = Regex(@"\{(.+?)\}", RegexOptions.Multiline)
 
-    /// Logger handler. Needs to be composed in the request after the fetch handler.
-    let log (msg: string) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
+    /// Logger handler with message. Needs to be composed in the request after the fetch handler.
+    let logWithMsg (msg: string) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
         let request = ctx.Request
 
         match request.Logger, request.LogLevel with
@@ -58,3 +58,7 @@ module Logging =
             logger.Log (request.LogLevel, format, valueArray)
         | _ -> ()
         next ctx
+
+    /// Logger handler. Needs to be composed in the request after the fetch handler.
+    let log (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
+        logWithMsg String.Empty next ctx

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -11,26 +11,11 @@ open Microsoft.Extensions.Logging
 [<AutoOpen>]
 module Logging =
 
-    let convert (format: string) (values: Map<string, obj>) =
-        let matches = Regex.Matches(format, @"\{(.+?)\}")
-        let valueArray =
-            matches
-            |> Seq.cast
-            |> Seq.map (fun (matche: Match) ->
-                let name = matche.Groups.[1].Value
-                if values.ContainsKey name then values.[name]
-                else String.Empty :> _
-            )
-            |> Array.ofSeq
-
-        valueArray
-
     let setLogger (logger: ILogger) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Logger = Some logger } }
 
     let setLogLevel (logLevel: LogLevel) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with LogLevel = logLevel } }
-
 
     // Pre-compiled
     let private reqex = Regex(@"\{(.+?)\}", RegexOptions.Multiline)

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -1,0 +1,75 @@
+// Copyright 2020 Cognite AS
+
+namespace Oryx
+
+open System
+open System.Collections.Generic
+open System.Net.Http
+open System.Text.RegularExpressions
+open Microsoft.Extensions.Logging
+
+[<AutoOpen>]
+module Logging =
+
+    let convert (format: string) (values: Map<string, obj>) =
+        let matches = Regex.Matches(format, @"\{(.+?)\}")
+        let valueArray =
+            matches
+            |> Seq.cast
+            |> Seq.map (fun (matche: Match) ->
+                let name = matche.Groups.[1].Value
+                if values.ContainsKey name then values.[name]
+                else String.Empty :> _
+            )
+            |> Array.ofSeq
+
+        valueArray
+
+    let setLogger (logger: ILogger) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+        next { context with Request = { context.Request with Logger = Some logger } }
+
+    let setLogLevel (logLevel: LogLevel) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+        next { context with Request = { context.Request with LogLevel = logLevel } }
+
+
+    // Pre-compiled
+    let private reqex = Regex(@"\{(.+?)\}", RegexOptions.Multiline)
+
+    /// Logger handler. Needs to be composed in the request after the fetch handler.
+    let log (msg: string) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
+        let request = ctx.Request
+
+        match request.Logger, request.LogLevel with
+        | _, LogLevel.None -> ()
+        | Some logger, _ ->
+            let format = ctx.Request.LogFormat
+            let matches = reqex.Matches format
+            // Create an array with values in the same order as in the format string. Important to be lazy and not
+            // stringify any values here. Only pass references to the objects themselves so the logger can stringify
+            // when / if the values are acutally being used / logged.
+            let valueArray =
+                matches
+                |> Seq.cast
+                |> Seq.map (fun (matche: Match) ->
+                    match matche.Groups.[1].Value with
+                    | "Method" -> box request.Method
+                    | "Content" ->
+                        ctx.Request.ContentBuilder
+                        |> Option.map (fun builder -> builder ())
+                        |> Option.toObj :> _
+                    | "Url" ->
+                        request.Extra.TryFind "Url"
+                        |> Option.map box |> Option.toObj
+                    | "Elapsed" ->
+                        ctx.Request.Extra.TryFind "Elapsed" |> (fun opt ->
+                            match opt with
+                            | Some (Number value) -> box value
+                            | _ -> null)
+                    | "Response" -> ctx.Response :> _
+                    | "Msg" -> msg :> _
+                    | _ -> String.Empty :> _
+                )
+                |> Array.ofSeq
+            logger.Log (request.LogLevel, format, valueArray)
+        | _ -> ()
+        next ctx

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -21,7 +21,7 @@ module Logging =
     let private reqex = Regex(@"\{(.+?)\}", RegexOptions.Multiline)
 
     /// Logger handler with message. Needs to be composed in the request after the fetch handler.
-    let logWithMsg (msg: string) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
+    let logWithMessage (msg: string) (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
         let request = ctx.Request
 
         match request.Logger, request.LogLevel with
@@ -37,8 +37,8 @@ module Logging =
                 |> Seq.cast
                 |> Seq.map (fun (matche: Match) ->
                     match matche.Groups.[1].Value with
-                    | "Method" -> box request.Method
-                    | "Content" ->
+                    | "HttpMethod" -> box request.Method
+                    | "RequestContent" ->
                         ctx.Request.ContentBuilder
                         |> Option.map (fun builder -> builder ())
                         |> Option.toObj :> _
@@ -50,8 +50,8 @@ module Logging =
                             match opt with
                             | Some (Number value) -> box value
                             | _ -> null)
-                    | "Response" -> ctx.Response :> _
-                    | "Msg" -> msg :> _
+                    | "ResponseContent" -> ctx.Response :> _
+                    | "Message" -> msg :> _
                     | _ -> String.Empty :> _
                 )
                 |> Array.ofSeq
@@ -61,4 +61,4 @@ module Logging =
 
     /// Logger handler. Needs to be composed in the request after the fetch handler.
     let log (next: HttpFunc<'a, 'r, 'err>) (ctx : Context<'a>) : HttpFuncResult<'r, 'err> =
-        logWithMsg String.Empty next ctx
+        logWithMessage String.Empty next ctx

--- a/src/Oryx.fsproj
+++ b/src/Oryx.fsproj
@@ -11,11 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Error.fs" />
     <Compile Include="Metrics.fs" />
     <Compile Include="Context.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="Handler.fs" />
+    <Compile Include="Error.fs" />
+    <Compile Include="Logging.fs" />
     <Compile Include="Fetch.fs" />
     <Compile Include="Retry.fs" />
     <Compile Include="Builder.fs" />

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -118,7 +118,7 @@ let post content =
     >=> fetch
     >=> withError errorHandler
     >=> json
-    >=> log "post"
+    >=> log
 
 let retryCount = 5
 let retry next ctx = retry shouldRetry 0<ms> retryCount next ctx

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -118,7 +118,7 @@ let post content =
     >=> fetch
     >=> withError errorHandler
     >=> json
-    >=> log
+    >=> log "post"
 
 let retryCount = 5
 let retry next ctx = retry shouldRetry 0<ms> retryCount next ctx

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -1,9 +1,9 @@
 module Tests.Fetch
 
 open System
+open System.Net
 open System.Net.Http
 open System.Threading
-open System.Net
 open System.Threading.Tasks
 
 open Microsoft.Extensions.Logging
@@ -200,7 +200,7 @@ let ``Get with logging is OK``() = task {
 
     // Act
     let request = req {
-        let! result = get () >=> log "request"
+        let! result = get () >=> log
         return result
     }
 
@@ -245,7 +245,7 @@ let ``Post with logging is OK``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> log msg
+        let! result = post content >=> logWithMsg msg
         return result
     }
 
@@ -284,12 +284,12 @@ let ``Post with disabled logging does not log``() = task {
         |> Context.setHttpClient client
         |> Context.setUrlBuilder (fun _ -> "http://test.org/")
         |> Context.addHeader ("api-key", "test-key")
-        |> Context.setLogger(logger)
+        |> Context.setLogger logger
         |> Context.setLogLevel LogLevel.None
 
     // Act
     let request = req {
-        let! result = post content >=> log msg
+        let! result = post content >=> logWithMsg msg
         return result
     }
 

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -245,7 +245,7 @@ let ``Post with logging is OK``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> logWithMsg msg
+        let! result = post content >=> logWithMessage msg
         return result
     }
 
@@ -289,7 +289,7 @@ let ``Post with disabled logging does not log``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> logWithMsg msg
+        let! result = post content >=> logWithMessage msg
         return result
     }
 

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -220,6 +220,7 @@ let ``Post with logging is OK``() = task {
     let mutable retries = 0
     let logger = new TestLogger<string>()
     let json = """{ "ping": 42 }"""
+    let msg = "custom message"
 
     let stub =
         Func<HttpRequestMessage,CancellationToken,Task<HttpResponseMessage>>(fun request token ->
@@ -244,7 +245,7 @@ let ``Post with logging is OK``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> log "post"
+        let! result = post content >=> log msg
         return result
     }
 
@@ -253,6 +254,7 @@ let ``Post with logging is OK``() = task {
 
     // Assert
     test <@ logger.Output.Contains json @>
+    test <@ logger.Output.Contains msg @>
     test <@ Result.isOk result @>
     test <@ retries' = 1 @>
 }
@@ -263,6 +265,7 @@ let ``Post with disabled logging does not log``() = task {
     let mutable retries = 0
     let logger = new TestLogger<string>()
     let json = """{ "value": 42 }"""
+    let msg = "custom message"
 
     let stub =
         Func<HttpRequestMessage,CancellationToken,Task<HttpResponseMessage>>(fun request token ->
@@ -286,7 +289,7 @@ let ``Post with disabled logging does not log``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> log "post"
+        let! result = post content >=> log msg
         return result
     }
 


### PR DESCRIPTION
- Add support for logging format string to client can choose what to log and what the log lines will look like. Thus the client can decide how light or strong the logging messages should be for development and production.
- Add separate `logWithMessage` operator so the resource endpoint can give a custom message that can be added to the log line using {Message} in the format string.
- Move logging handling to a separate file.
- Move error handling to `Error.fs`. 