### PR TITLE
Refactor metrics handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ You can also use a custom log format string by setting the log format using `set
 - `RequestContent` - The request content being sent. Must implement `ToString` to give meaningful output.
 - `Url` - The URL used for fetching.
 
-**Note:** Oryx will not not call `.ToString ()` but will hand it over to the `ILogger` for the actual string interpolation, given that the message will actually end up being logged.
+**Note:** Oryx will not call `.ToString ()` but will hand it over to the `ILogger` for the actual string interpolation, given that the message will actually end up being logged.
 
 There are to logging handlers. One without a message and one where you can supply a custom message that may be added to the logging output (see format string). The logging handlers do not alter the types of the pipeline and may be composed anywhere. But to give meaningful output they should be composed after fetching (`fetch`).
 

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -71,8 +71,7 @@ module Context =
     /// Note that lazy content may not work with retry, logging etc where content may have been disposed.
     let lazyContent content = Some <| fun () -> content
 
-
-    let defaultLogFormat = "Oryx: {Message} {HttpMethod} {Uri} > \n{RequestContent}{ResponseContent}"
+    let defaultLogFormat = "Oryx: {Message} {HttpMethod} {Uri}\n→ {RequestContent}\n← {ResponseContent}"
 
     /// Default context to use.
     let defaultRequest =
@@ -93,8 +92,7 @@ module Context =
             Extra = Map.empty
         }
 
-    let defaultResult =
-        new HttpResponseMessage (HttpStatusCode.NotFound)
+    let defaultResult = new HttpResponseMessage (HttpStatusCode.NotFound)
 
     let defaultContext : Context<HttpResponseMessage> = {
         Request = defaultRequest

--- a/src/Error.fs
+++ b/src/Error.fs
@@ -23,7 +23,7 @@ module Error =
             match response.IsSuccessStatusCode with
             | true -> return! next ctx
             | false ->
-                ctx.Request.Metrics.TraceFetchErrorInc 1L
+                ctx.Request.Metrics.Counter Metric.FetchErrorInc Map.empty 1L
 
                 let! err = errorHandler response
                 return err |> Error

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -69,10 +69,10 @@ module Fetch =
                 timer.Start ()
                 // Note: we don't use `use!` for response since the next handler will never throw exceptions. Thus we
                 // can dispose ourselves which is much faster than using `use!`.
-                ctx.Request.Metrics.TraceFetchInc 1L
+                ctx.Request.Metrics.Counter Metric.FetchInc Map.empty 1L
                 let! response = client.SendAsync (request, cancellationToken)
                 timer.Stop ()
-                ctx.Request.Metrics.TraceFetchLatencyUpdate timer.ElapsedMilliseconds
+                ctx.Request.Metrics.Gauge Metric.FetchLatencyUpdate Map.empty (float timer.ElapsedMilliseconds)
 
                 let! result = next { ctx with Response = response; Request = { ctx.Request with Extra = ctx.Request.Extra.Add("Url", Url request.RequestUri) } }
                 response.Dispose ()

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -121,7 +121,7 @@ module Handler =
                 return! next { Request = ctx.Request; Response = a }
             with
             | ex ->
-                ctx.Request.Metrics.TraceDecodeErrorInc 1L
+                ctx.Request.Metrics.Counter Metric.DecodeErrorInc Map.empty 1L
                 return Error (Panic ex)
         }
 
@@ -133,7 +133,7 @@ module Handler =
                 return! next { Request = ctx.Request; Response = a }
             with
             | ex ->
-                ctx.Request.Metrics.TraceDecodeErrorInc 1L
+                ctx.Request.Metrics.Counter Metric.DecodeErrorInc Map.empty 1L
                 return Error (Panic ex)
         }
 

--- a/src/Metrics.fs
+++ b/src/Metrics.fs
@@ -1,18 +1,22 @@
-// Copyright 2019 Cognite AS
+// Copyright 2020 Cognite AS
 
 namespace Oryx
 
+open System.Collections.Generic
+
+/// Pre-defined events. Just a string so custom HttpHandlers are free to add their own events.
+module Metric =
+    let [<Literal>] FetchInc = "MetricFetchInc"
+    let [<Literal>] FetchErrorInc = "MetricFetchErrorInc"
+    let [<Literal>] FetchRetryInc = "MetricFetchRetryInc"
+    let [<Literal>] FetchLatencyUpdate = "MetricFetchLatencyUpdate"
+    let [<Literal>] DecodeErrorInc = "MetricDecodeErrorInc"
+
 type IMetrics =
-    abstract member TraceFetchInc : int64 -> unit
-    abstract member TraceFetchErrorInc : int64 -> unit
-    abstract member TraceFetchRetryInc : int64 -> unit
-    abstract member TraceFetchLatencyUpdate : int64 -> unit
-    abstract member TraceDecodeErrorInc : int64 -> unit
+    abstract member Counter : metric: string -> labels: IDictionary<string, string> -> increase: int64 -> unit
+    abstract member Gauge : metric: string -> labels: IDictionary<string, string> -> value: float -> unit
 
 type EmptyMetrics () =
     interface IMetrics with
-        member this.TraceFetchInc _ = ()
-        member this.TraceFetchErrorInc _ = ()
-        member this.TraceFetchRetryInc _ = ()
-        member this.TraceFetchLatencyUpdate _ = ()
-        member this.TraceDecodeErrorInc _ = ()
+        member _.Counter _ _ _ = ()
+        member _.Gauge _ _ _ = ()

--- a/src/Retry.fs
+++ b/src/Retry.fs
@@ -34,7 +34,7 @@ module Retry =
         | Error err ->
             if shouldRetry err && maxRetries > 0 then
                 do! int initialDelay |> Async.Sleep
-                ctx.Request.Metrics.TraceFetchRetryInc 1L
+                ctx.Request.Metrics.Counter Metric.FetchRetryInc Map.empty 1L
                 return! retry shouldRetry nextDelay (maxRetries - 1) next ctx
             else
                 return result


### PR DESCRIPTION
- Do not hard code metric types. They are hard-coded sort of, but just a string so any handler can add custom metrics.
- Make logging extensible by looking for place-holders in the Extra property bag.
- Make the logging place-holder reqexp compiled for improved performance.