### PR TITLE
Add a new context function withHttpClientFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,18 +295,18 @@ let runAsync (handler: HttpHandler<'a,'r,'r, 'err>) (ctx : Context<'a>) : Task<R
 Oryx supports logging using the logging handlers. To setup for logging you first need to enable logging in the context by both setting a logger of type `ILogger` ([Microsoft.Extensions.Logging](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger?view=dotnet-plat-ext-3.1)) and the logging level to something higher than `LogLevel.None`.
 
 ```fs
-val setLogger : (logger: ILogger) -> (context: HttpContext) -> (context: HttpContext)
+val withLogger : (logger: ILogger) -> (context: HttpContext) -> (context: HttpContext)
 
-val setLogLevel : (logLevel: LogLevel) -> (context: HttpContext) -> (context: HttpContext)
+val withLogLevel : (logLevel: LogLevel) -> (context: HttpContext) -> (context: HttpContext)
 
-val setLogFormat (format: string) (context: HttpContext) -> (context: HttpContext)
+val withLogFormat (format: string) (context: HttpContext) -> (context: HttpContext)
 ```
 
 The default format string is:
 
 `"Oryx: {Message} {HttpMethod} {Uri}\n{RequestContent}\n{ResponseContent}"`
 
-You can also use a custom log format string by setting the log format using `setLogFormat`. The available place holders you may use are:
+You can also use a custom log format string by setting the log format using `withLogFormat`. The available place holders you may use are:
 
 - `Elapsed` - The elapsed request time for `fetch` in milliseconds.
 - `HttpMethod` - The HTTP method used, i.e `PUT`, `GET`, `POST`, `DELETE` or `PATCH`.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ This enables you to compose your web requests and decode the response, e.g as we
         let url = Url +/ "list"
 
         POST
-        >=> setVersion V10
-        >=> setResource url
-        >=> setContent (() -> new JsonPushStreamContent<AssetQuery>(query, jsonOptions))
+        >=> withVersion V10
+        >=> withResource url
+        >=> withContent (() -> new JsonPushStreamContent<AssetQuery>(query, jsonOptions))
         >=> fetch
         >=> withError decodeError
         >=> json jsonOptions
@@ -348,14 +348,14 @@ Labels are currently not set but are added for future use, e.g setting the error
 It's easy to extend Oryx with your own HTTP handlers.
 
 ```fs
-let setResource (resource: string) (next: NextFunc<_,_>) (context: HttpContext) =
+let withResource (resource: string) (next: NextFunc<_,_>) (context: HttpContext) =
     next { context with Request = { context.Request with Extra = context.Request.Extra.Add("resource", String resource) } }
 
-let setVersion (version: ApiVersion) (next: NextFunc<_,_>) (context: HttpContext) =
+let withVersion (version: ApiVersion) (next: NextFunc<_,_>) (context: HttpContext) =
     next { context with Request = { context.Request with Extra = context.Request.Extra.Add("apiVersion", String (version.ToString ())) } }
 ```
 
-The handlers above will add custom values to the context that may be used by the supplied URL builder.
+The handlers above will add custom values to the context that may be used by the supplied URL builder. Note that anything added to the `Extra` property bag is also available as place-holders in the logging format string.
 
 ```fs
 let urlBuilder (request: HttpRequest) : string =

--- a/benchmark/Classic.fs
+++ b/benchmark/Classic.fs
@@ -66,11 +66,7 @@ module ClassicHandler =
         withUrlBuilder (fun _ -> url) context
 
     let fetch<'err> (ctx: HttpContext) : HttpFuncResultClassic<HttpResponseMessage, 'err> =
-        let client =
-            match ctx.Request.HttpClient with
-            | Some client -> client
-            | None -> failwith "Must set httpClient"
-
+        let client = ctx.Request.HttpClient ()
         use source = new CancellationTokenSource()
         let cancellationToken =
             match ctx.Request.CancellationToken with

--- a/benchmark/Classic.fs
+++ b/benchmark/Classic.fs
@@ -59,11 +59,11 @@ module ClassicHandler =
                 return err |> Error
         }
 
-    let setUrlBuilder<'r, 'err> (builder: UrlBuilder) (context: HttpContext) =
+    let withUrlBuilder<'r, 'err> (builder: UrlBuilder) (context: HttpContext) =
         Ok { context with Request = { context.Request with UrlBuilder = builder } } |> Task.FromResult
 
     let setUrl<'r, 'err> (url: string) (context: HttpContext) =
-        setUrlBuilder (fun _ -> url) context
+        withUrlBuilder (fun _ -> url) context
 
     let fetch<'err> (ctx: HttpContext) : HttpFuncResultClassic<HttpResponseMessage, 'err> =
         let client =

--- a/benchmark/Common.fs
+++ b/benchmark/Common.fs
@@ -64,7 +64,7 @@ let noop (next: NextFunc<int, int, 'err>) (ctx: Context<'a>) : HttpFuncResult<in
 
 let get () =
     GET
-    >=> setUrl "http://test"
+    >=> withUrl "http://test"
     >=> fetch
     >=> withError decodeError
     >=> json decoder
@@ -74,7 +74,7 @@ let get () =
 let getList () =
 
     GET
-    >=> setUrl "http://test"
+    >=> withUrl "http://test"
     >=> fetch
     >=> withError decodeError
     >=> json listDecoder
@@ -126,7 +126,7 @@ let jsonReader<'a, 'r, 'err> (reader: Stream -> Task<Result<'a, string>>) (next:
 
 let getJson (reader: Stream -> Task<Result<TestType seq, string>>) : HttpHandler<HttpResponseMessage, TestType seq, 'b, TestError> =
     GET
-    >=> setUrl "http://test"
+    >=> withUrl "http://test"
     >=> fetch
     >=> withError decodeError
     >=> jsonReader reader

--- a/benchmark/Fetch.fs
+++ b/benchmark/Fetch.fs
@@ -47,8 +47,8 @@ type FetchBenchmark () =
         ctx <-
             Context.defaultContext
             |> Context.setHttpClient client
-            |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-            |> Context.addHeader ("api-key", "test-key")
+            |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+            |> Context.withHeader ("api-key", "test-key")
 
 
     [<Benchmark(Description = "Oryx", Baseline = true)>]

--- a/benchmark/Fetch.fs
+++ b/benchmark/Fetch.fs
@@ -46,7 +46,7 @@ type FetchBenchmark () =
 
         ctx <-
             Context.defaultContext
-            |> Context.setHttpClient client
+            |> Context.withHttpClient client
             |> Context.withUrlBuilder (fun _ -> "http://test.org/")
             |> Context.withHeader ("api-key", "test-key")
 

--- a/benchmark/Json.fs
+++ b/benchmark/Json.fs
@@ -43,8 +43,8 @@ type JsonBenchmark () =
         ctx <-
             Context.defaultContext
             |> Context.setHttpClient client
-            |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-            |> Context.addHeader ("api-key", "test-key")
+            |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+            |> Context.withHeader ("api-key", "test-key")
 
 
     [<Benchmark(Description = "Toth", Baseline = true)>]

--- a/benchmark/Json.fs
+++ b/benchmark/Json.fs
@@ -42,7 +42,7 @@ type JsonBenchmark () =
 
         ctx <-
             Context.defaultContext
-            |> Context.setHttpClient client
+            |> Context.withHttpClient client
             |> Context.withUrlBuilder (fun _ -> "http://test.org/")
             |> Context.withHeader ("api-key", "test-key")
 

--- a/benchmark/Ply.fs
+++ b/benchmark/Ply.fs
@@ -62,13 +62,13 @@ module Handler =
                 return err |> Error
         }
 
-    let setUrlBuilder<'r, 'err> (builder: UrlBuilder) (context: HttpContext) =
+    let withUrlBuilder<'r, 'err> (builder: UrlBuilder) (context: HttpContext) =
         uply {
             return Ok { context with Request = { context.Request with UrlBuilder = builder } }
         }
 
     let setUrl<'r, 'err> (url: string) (context: HttpContext) =
-        setUrlBuilder (fun _ -> url) context
+        withUrlBuilder (fun _ -> url) context
 
     let fetch<'err> (ctx: HttpContext) : HttpFuncResultPly<HttpResponseMessage, 'err> =
         let client =

--- a/benchmark/Ply.fs
+++ b/benchmark/Ply.fs
@@ -67,15 +67,11 @@ module Handler =
             return Ok { context with Request = { context.Request with UrlBuilder = builder } }
         }
 
-    let setUrl<'r, 'err> (url: string) (context: HttpContext) =
+    let withUrl<'r, 'err> (url: string) (context: HttpContext) =
         withUrlBuilder (fun _ -> url) context
 
     let fetch<'err> (ctx: HttpContext) : HttpFuncResultPly<HttpResponseMessage, 'err> =
-        let client =
-            match ctx.Request.HttpClient with
-            | Some client -> client
-            | None -> failwith "Must set httpClient"
-
+        let client = ctx.Request.HttpClient ()
         use source = new CancellationTokenSource()
         let cancellationToken =
             match ctx.Request.CancellationToken with
@@ -118,7 +114,7 @@ module Handler =
 
     let get () =
         GET
-        >=> setUrl "http://test"
+        >=> withUrl "http://test"
         >=> fetch
         >=> withError decodeError
         >=> json decoder

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -23,6 +23,13 @@ type Value =
     | Number of int64
     | Url of Uri
 
+    // Give proper output for logging
+    override x.ToString () =
+        match x with
+        | String str -> str
+        | Number num -> num.ToString ()
+        | Url uri -> uri.ToString ()
+
 type PropertyBag = Map<string, Value>
 type UrlBuilder = HttpRequest -> string
 

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -75,9 +75,6 @@ module Context =
         let version = Assembly.GetExecutingAssembly().GetName().Version
         {| Major=version.Major; Minor=version.Minor; Build=version.Build |}
 
-    /// Note that lazy content may not work with retry, logging etc where content may have been disposed.
-    let lazyContent content = Some <| fun () -> content
-
     let defaultLogFormat = "Oryx: {Message} {HttpMethod} {Uri}\n→ {RequestContent}\n← {ResponseContent}"
 
     /// Default context to use.

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -121,7 +121,7 @@ module Context =
         { context with Request = { context.Request with Headers = header :: context.Request.Headers  } }
 
     /// Set the HTTP client to use for the requests.
-    let setHttpClient (client: HttpClient) (context: HttpContext) =
+    let withHttpClient (client: HttpClient) (context: HttpContext) =
         { context with Request = { context.Request with HttpClient = (fun () -> client) } }
 
     /// Set the HTTP client factory to use for the requests.

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -28,7 +28,7 @@ type UrlBuilder = HttpRequest -> string
 
 and HttpRequest = {
     /// HTTP client to use for sending the request.
-    HttpClient: HttpClient option
+    HttpClient: unit -> HttpClient
     /// HTTP method to be used.
     Method: HttpMethod
     /// Getter for content to be sent as body of the request. We use a getter so content may be re-created for retries.
@@ -77,7 +77,7 @@ module Context =
     let defaultRequest =
         let ua = sprintf "Oryx / v%d.%d.%d (Cognite)" version.Major version.Minor version.Build
         {
-            HttpClient = None
+            HttpClient = (fun () -> failwith "Must set HttpClient")
             Method = HttpMethod.Get
             ContentBuilder = None
             Query = List.empty
@@ -94,37 +94,53 @@ module Context =
 
     let defaultResult = new HttpResponseMessage (HttpStatusCode.NotFound)
 
+    /// The default context.
     let defaultContext : Context<HttpResponseMessage> = {
         Request = defaultRequest
         Response = defaultResult
     }
 
     /// Add HTTP header to context.
-    let addHeader (header: string*string) (context: HttpContext) =
+    let withHeader (header: string*string) (context: HttpContext) =
         { context with Request = { context.Request with Headers = header :: context.Request.Headers  } }
 
+    /// Add a list of headers to the context.
+    let withHeaders (headers: (string*string) list) (context: HttpContext) =
+        { context with Request = { context.Request with Headers = List.append headers context.Request.Headers } }
+
     /// Helper for setting Bearer token as Authorization header.
-    let setToken (token: string) (context: HttpContext) =
+    let withBearerToken (token: string) (context: HttpContext) =
         let header = ("Authorization", sprintf "Bearer %s" token)
         { context with Request = { context.Request with Headers = header :: context.Request.Headers  } }
 
+    /// Set the HTTP client to use for the requests.
     let setHttpClient (client: HttpClient) (context: HttpContext) =
-        { context with Request = { context.Request with HttpClient = Some client } }
+        { context with Request = { context.Request with HttpClient = (fun () -> client) } }
 
-    let setUrlBuilder (builder: HttpRequest -> string) (context: HttpContext) =
+    /// Set the HTTP client factory to use for the requests.
+    let withHttpClientFactory (factory: unit -> HttpClient) (context: HttpContext) =
+        { context with Request = { context.Request with HttpClient = factory } }
+
+    /// Set the URL builder to use.
+    let withUrlBuilder (builder: HttpRequest -> string) (context: HttpContext) =
         { context with Request = { context.Request with UrlBuilder = builder } }
 
-    let setCancellationToken (token: CancellationToken) (context: HttpContext) =
+    /// Set a cancellation token to use for the requests.
+    let withCancellationToken (token: CancellationToken) (context: HttpContext) =
         { context with Request = { context.Request with CancellationToken = Some token } }
 
-    let setLogger (logger: ILogger) (context: HttpContext) =
+    /// Set the logger (ILogger) to use.
+    let withLogger (logger: ILogger) (context: HttpContext) =
         { context with Request = { context.Request with Logger = Some logger } }
 
-    let setLogLevel (logLevel: LogLevel) (context: HttpContext) =
+    /// Set the log level to use (default is LogLevel.None).
+    let withLogLevel (logLevel: LogLevel) (context: HttpContext) =
         { context with Request = { context.Request with LogLevel = logLevel } }
 
-    let setLogFormat (format: string) (context: HttpContext) =
+    /// Set the log format to use.
+    let withLogFormat (format: string) (context: HttpContext) =
         { context with Request = { context.Request with LogFormat = format } }
 
-    let setMetrics (metrics: IMetrics) (context: HttpContext) =
+    /// Set the metrics (IMetrics) to use.
+    let withMetrics (metrics: IMetrics) (context: HttpContext) =
         { context with Request = { context.Request with Metrics = metrics } }

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -52,10 +52,7 @@ module Fetch =
 
     let fetch<'r, 'err> (next: NextFunc<HttpResponseMessage, 'r, 'err>) (ctx: HttpContext) : HttpFuncResult<'r, 'err> =
         let timer = Stopwatch ()
-        let client =
-            match ctx.Request.HttpClient with
-            | Some client -> client
-            | None -> failwith "Must set httpClient"
+        let client = ctx.Request.HttpClient ()
 
         use source = new CancellationTokenSource()
         let cancellationToken =

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -50,6 +50,8 @@ module Fetch =
         | None -> ()
         request
 
+    /// Fetch content using the given context. Exposes `{Url}`, `{ResponseContent}`, `{RequestContent}` and `{Elapsed}`
+    /// to the log format.
     let fetch<'r, 'err> (next: NextFunc<HttpResponseMessage, 'r, 'err>) (ctx: HttpContext) : HttpFuncResult<'r, 'err> =
         let timer = Stopwatch ()
         let client = ctx.Request.HttpClient ()
@@ -70,8 +72,8 @@ module Fetch =
                 let! response = client.SendAsync (request, cancellationToken)
                 timer.Stop ()
                 ctx.Request.Metrics.Gauge Metric.FetchLatencyUpdate Map.empty (float timer.ElapsedMilliseconds)
-
-                let! result = next { ctx with Response = response; Request = { ctx.Request with Extra = ctx.Request.Extra.Add("Url", Url request.RequestUri) } }
+                let extra = ctx.Request.Extra.Add("Url", Url request.RequestUri).Add("Elapsed", Number timer.ElapsedMilliseconds)
+                let! result = next { ctx with Response = response; Request = { ctx.Request with Extra = extra }}
                 response.Dispose ()
                 return result
             with

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -51,26 +51,26 @@ module Handler =
 
     /// Add query parameters to context. These parameters will be added
     /// to the query string of requests that uses this context.
-    let addQuery (query: struct (string * string) seq) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withQuery (query: struct (string * string) seq) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Query = query } }
 
     /// Add content builder to context. These content will be added to the HTTP body of
     /// requests that uses this context.
-    let setContent (builder: unit -> HttpContent) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withContent (builder: unit -> HttpContent) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with ContentBuilder = Some builder } }
 
-    let setResponseType (respType: ResponseType) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withResponseType (respType: ResponseType) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with ResponseType = respType }}
 
     /// Set the method to be used for requests using this context.
-    let setMethod<'r, 'err> (method: HttpMethod) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withMethod<'r, 'err> (method: HttpMethod) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Method = method } }
 
     let withUrlBuilder<'r, 'err> (builder: UrlBuilder) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with UrlBuilder = builder } }
 
     // A basic way to set the request URL. Use custom builders for more advanced usage.
-    let setUrl<'r, 'err> (url: string) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withUrl<'r, 'err> (url: string) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         withUrlBuilder (fun _ -> url) next context
 
     /// Http GET request. Also clears any content set in the context.
@@ -78,9 +78,9 @@ module Handler =
         next { context with Request = { context.Request with Method = HttpMethod.Get; ContentBuilder = None } }
 
     /// Http POST request.
-    let POST<'r, 'err> = setMethod<'r, 'err> HttpMethod.Post
+    let POST<'r, 'err> = withMethod<'r, 'err> HttpMethod.Post
     /// Http DELETE request.
-    let DELETE<'r, 'err> = setMethod<'r, 'err> HttpMethod.Delete
+    let DELETE<'r, 'err> = withMethod<'r, 'err> HttpMethod.Delete
 
     /// Run list of HTTP handlers concurrently.
     let concurrent (handlers : HttpHandler<'a, 'b, 'b, 'err> seq) (next: NextFunc<'b list, 'r, 'err>) (ctx: Context<'a>) : HttpFuncResult<'r, 'err> = task {

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -66,12 +66,12 @@ module Handler =
     let setMethod<'r, 'err> (method: HttpMethod) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Method = method } }
 
-    let setUrlBuilder<'r, 'err> (builder: UrlBuilder) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withUrlBuilder<'r, 'err> (builder: UrlBuilder) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with UrlBuilder = builder } }
 
     // A basic way to set the request URL. Use custom builders for more advanced usage.
     let setUrl<'r, 'err> (url: string) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
-        setUrlBuilder (fun _ -> url) next context
+        withUrlBuilder (fun _ -> url) next context
 
     /// Http GET request. Also clears any content set in the context.
     let GET<'r, 'err> (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -41,18 +41,10 @@ module Logging =
                         ctx.Request.ContentBuilder
                         |> Option.map (fun builder -> builder ())
                         |> Option.toObj :> _
-                    | "Url" ->
-                        request.Extra.TryFind "Url"
-                        |> Option.map box |> Option.toObj
-                    | "Elapsed" ->
-                        ctx.Request.Extra.TryFind "Elapsed" |> (fun opt ->
-                            match opt with
-                            | Some (Number value) -> box value
-                            | _ -> null)
                     | "ResponseContent" -> ctx.Response :> _
                     | "Message" -> msg :> _
                     | key ->
-                        // Look for the key in the extra info. This enables custom HTTP handlers to add custom
+                        // Look for the key in the extra info. This also enables custom HTTP handlers to add custom
                         // placeholders to the format string.
                         match ctx.Request.Extra.TryFind key with
                         | Some value -> value :> _

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -10,10 +10,10 @@ open Microsoft.Extensions.Logging
 [<AutoOpen>]
 module Logging =
 
-    let setLogger (logger: ILogger) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withLogger (logger: ILogger) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with Logger = Some logger } }
 
-    let setLogLevel (logLevel: LogLevel) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
+    let withLogLevel (logLevel: LogLevel) (next: NextFunc<HttpResponseMessage,'r, 'err>) (context: HttpContext) =
         next { context with Request = { context.Request with LogLevel = logLevel } }
 
     // Pre-compiled

--- a/src/Metrics.fs
+++ b/src/Metrics.fs
@@ -20,3 +20,10 @@ type EmptyMetrics () =
     interface IMetrics with
         member _.Counter _ _ _ = ()
         member _.Gauge _ _ _ = ()
+
+
+type Update<'a> =
+    | Set of 'a
+    | SetNull
+    | Add of 'a
+    | Remove of 'a

--- a/src/Metrics.fs
+++ b/src/Metrics.fs
@@ -20,10 +20,3 @@ type EmptyMetrics () =
     interface IMetrics with
         member _.Counter _ _ _ = ()
         member _.Gauge _ _ _ = ()
-
-
-type Update<'a> =
-    | Set of 'a
-    | SetNull
-    | Add of 'a
-    | Remove of 'a

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -78,7 +78,6 @@ let apiError msg (next: NextFunc<'b, 'c, 'err>) (_: Context<'a>) : HttpFuncResul
 let error msg (next: NextFunc<'b, 'c, 'err>) (_: Context<'a>) : HttpFuncResult<'c, TestError> =
    TestException msg |> Panic |> Error |> Task.FromResult
 
-
 /// A bad request handler to use with the `catch` handler. It takes a response to return as Ok.
 let badRequestHandler<'a, 'b> (response: 'b) (error: HandlerError<TestError>) (ctx : Context<'a>) = task {
     match error with
@@ -102,20 +101,19 @@ let errorHandler (response : HttpResponseMessage) = task {
 let json (next: NextFunc<string, 'c, 'err>) (ctx: Context<HttpResponseMessage>) : HttpFuncResult<'c, 'err> =
     parseAsync (fun stream -> task { return! ctx.Response.Content.ReadAsStringAsync () }) next ctx
 
-
 let get () =
     GET
-    >=> setUrl "http://test"
-    >=> addQuery [ struct ("debug", "true") ]
+    >=> withUrl "http://test"
+    >=> withQuery [ struct ("debug", "true") ]
     >=> fetch
     >=> withError errorHandler
     >=> json
 
 let post content =
     POST
-    >=> setUrl "http://test"
-    >=> setResponseType JsonValue
-    >=> setContent content
+    >=> withUrl "http://test"
+    >=> withResponseType JsonValue
+    >=> withContent content
     >=> fetch
     >=> withError errorHandler
     >=> json

--- a/test/Context.fs
+++ b/test/Context.fs
@@ -36,6 +36,12 @@ let ``Adding http client creates a context with that http client`` () =
     ctx.Request.HttpClient () = client
 
 [<Property>]
+let ``Adding http client factory creates a context with that http client`` () =
+    let client = new HttpClient()
+    let ctx = Context.defaultContext |> Context.withHttpClientFactory (fun () -> client)
+    ctx.Request.HttpClient () = client
+
+[<Property>]
 let ``Adding url builder creates a context with that url builder`` () =
     let urlBuilder = fun (req: HttpRequest) -> "test"
     let ctx = Context.defaultContext |> Context.withUrlBuilder urlBuilder

--- a/test/Context.fs
+++ b/test/Context.fs
@@ -32,7 +32,7 @@ let ``Adding a bearer token to a context creates a context with that token`` tok
 [<Property>]
 let ``Adding http client creates a context with that http client`` () =
     let client = new HttpClient()
-    let ctx = Context.defaultContext |> Context.setHttpClient client
+    let ctx = Context.defaultContext |> Context.withHttpClient client
     ctx.Request.HttpClient () = client
 
 [<Property>]

--- a/test/Context.fs
+++ b/test/Context.fs
@@ -8,15 +8,15 @@ open FsCheck.Xunit
 
 [<Property>]
 let ``Adding a header to a context creates a context that contains that header`` header =
-    let ctx = Context.defaultContext |> Context.addHeader header
+    let ctx = Context.defaultContext |> Context.withHeader header
     List.contains header ctx.Request.Headers
 
 [<Property>]
 let ``Adding two headers to a context creates a context that contains both headers`` h1 h2 =
     let ctx =
         Context.defaultContext
-        |> Context.addHeader h1
-        |> Context.addHeader h2
+        |> Context.withHeader h1
+        |> Context.withHeader h2
 
     let p1 = List.contains h1 ctx.Request.Headers
     let p2 = List.contains h2 ctx.Request.Headers
@@ -24,7 +24,7 @@ let ``Adding two headers to a context creates a context that contains both heade
 
 [<Property>]
 let ``Adding a bearer token to a context creates a context with that token`` token =
-    let ctx = Context.defaultContext |> Context.setToken token
+    let ctx = Context.defaultContext |> Context.withBearerToken token
     ctx.Request.Headers
     |> List.exists (fun (header, value) ->
         header = "Authorization" && value = (sprintf "Bearer %s" token))
@@ -33,16 +33,16 @@ let ``Adding a bearer token to a context creates a context with that token`` tok
 let ``Adding http client creates a context with that http client`` () =
     let client = new HttpClient()
     let ctx = Context.defaultContext |> Context.setHttpClient client
-    ctx.Request.HttpClient = Some client
+    ctx.Request.HttpClient () = client
 
 [<Property>]
 let ``Adding url builder creates a context with that url builder`` () =
     let urlBuilder = fun (req: HttpRequest) -> "test"
-    let ctx = Context.defaultContext |> Context.setUrlBuilder urlBuilder
+    let ctx = Context.defaultContext |> Context.withUrlBuilder urlBuilder
     ctx.Request.UrlBuilder ctx.Request = "test"
 
 [<Property>]
 let ``Adding cancellation token creates a context with that cancellation token`` () =
     let cancellationToken = CancellationToken.None
-    let ctx = Context.defaultContext |> Context.setCancellationToken cancellationToken
+    let ctx = Context.defaultContext |> Context.withCancellationToken cancellationToken
     ctx.Request.CancellationToken = Some cancellationToken

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -236,7 +236,7 @@ let ``Post with logging is OK``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.withHttpClient client
+        |> Context.withHttpClientFactory (fun () -> client)
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withLogger(logger)

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -36,8 +36,8 @@ let ``Get with return expression is Ok``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
 
     // Act
     let request = req {
@@ -74,8 +74,8 @@ let ``Post url encoded with return expression is Ok``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
 
     let query = Seq.singleton ("foo", "bar")
     let content = FormUrlEncodedContent.FromTuples query
@@ -113,9 +113,9 @@ let ``Fetch with retry is Ok``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
-        |> Context.setMetrics metrics
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
+        |> Context.withMetrics metrics
 
     // Act
     let request =
@@ -152,9 +152,9 @@ let ``Fetch with retry on internal error will retry``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
-        |> Context.setMetrics metrics
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
+        |> Context.withMetrics metrics
 
     // Act
     let request =
@@ -192,11 +192,11 @@ let ``Get with logging is OK``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
-        |> Context.setMetrics metrics
-        |> Context.setLogger logger
-        |> Context.setLogLevel LogLevel.Debug
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
+        |> Context.withMetrics metrics
+        |> Context.withLogger logger
+        |> Context.withLogLevel LogLevel.Debug
 
     // Act
     let request = req {
@@ -237,10 +237,10 @@ let ``Post with logging is OK``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
-        |> Context.setLogger(logger)
-        |> Context.setLogLevel LogLevel.Debug
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
+        |> Context.withLogger(logger)
+        |> Context.withLogLevel LogLevel.Debug
 
 
     // Act
@@ -282,10 +282,10 @@ let ``Post with disabled logging does not log``() = task {
     let ctx =
         Context.defaultContext
         |> Context.setHttpClient client
-        |> Context.setUrlBuilder (fun _ -> "http://test.org/")
-        |> Context.addHeader ("api-key", "test-key")
-        |> Context.setLogger logger
-        |> Context.setLogLevel LogLevel.None
+        |> Context.withUrlBuilder (fun _ -> "http://test.org/")
+        |> Context.withHeader ("api-key", "test-key")
+        |> Context.withLogger logger
+        |> Context.withLogLevel LogLevel.None
 
     // Act
     let request = req {

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -35,7 +35,7 @@ let ``Get with return expression is Ok``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
 
@@ -73,7 +73,7 @@ let ``Post url encoded with return expression is Ok``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
 
@@ -112,7 +112,7 @@ let ``Fetch with retry is Ok``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withMetrics metrics
@@ -151,7 +151,7 @@ let ``Fetch with retry on internal error will retry``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withMetrics metrics
@@ -191,7 +191,7 @@ let ``Get with logging is OK``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withMetrics metrics
@@ -236,7 +236,7 @@ let ``Post with logging is OK``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withLogger(logger)
@@ -281,7 +281,7 @@ let ``Post with disabled logging does not log``() = task {
 
     let ctx =
         Context.defaultContext
-        |> Context.setHttpClient client
+        |> Context.withHttpClient client
         |> Context.withUrlBuilder (fun _ -> "http://test.org/")
         |> Context.withHeader ("api-key", "test-key")
         |> Context.withLogger logger


### PR DESCRIPTION
- Rename the other context functions to `with*` instead of `set*` since we are not mutating the context.