### PR TITLE
Add withTokenProvider HTTP handler

### DIFF
--- a/benchmark/Classic.fs
+++ b/benchmark/Classic.fs
@@ -67,11 +67,7 @@ module ClassicHandler =
 
     let fetch<'TError> (ctx: HttpContext) : HttpFuncResultClassic<HttpResponseMessage, 'TError> =
         let client = ctx.Request.HttpClient ()
-        use source = new CancellationTokenSource()
-        let cancellationToken =
-            match ctx.Request.CancellationToken with
-            | Some token -> token
-            | None -> source.Token
+        let cancellationToken = ctx.Request.CancellationToken
 
         task {
             try

--- a/benchmark/Ply.fs
+++ b/benchmark/Ply.fs
@@ -72,11 +72,7 @@ module Handler =
 
     let fetch<'TError> (ctx: HttpContext) : HttpFuncResultPly<HttpResponseMessage, 'TError> =
         let client = ctx.Request.HttpClient ()
-        use source = new CancellationTokenSource()
-        let cancellationToken =
-            match ctx.Request.CancellationToken with
-            | Some token -> token
-            | None -> source.Token
+        let cancellationToken = ctx.Request.CancellationToken
 
         uply {
             try

--- a/extensions/Oryx.NewtonsoftJson/JsonPushStreamContent.fs
+++ b/extensions/Oryx.NewtonsoftJson/JsonPushStreamContent.fs
@@ -1,8 +1,8 @@
 namespace Oryx.NewtonsoftJson
 
-open System.Net.Http
 open System.IO
 open System.Net
+open System.Net.Http
 open System.Net.Http.Headers
 open System.Text
 open System.Threading.Tasks

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -7,7 +7,6 @@ open System.Net
 open System.Net.Http
 open System.Reflection
 open System.Threading
-open System.Threading.Tasks
 
 open Microsoft.Extensions.Logging
 
@@ -46,8 +45,6 @@ and HttpRequest = {
     ResponseType: ResponseType
     /// List of headers to be sent
     Headers: Map<string, string>
-    /// Authorization handler
-    Authorize: (CancellationToken -> Task<string option>)
     /// A function that builds the request URL based on the collected extra info.
     UrlBuilder: UrlBuilder
     /// Optional CancellationToken for cancelling the request.
@@ -89,7 +86,6 @@ module Context =
             Query = List.empty
             ResponseType = JsonValue
             Headers = [ "User-Agent", ua ] |> Map
-            Authorize = (fun _ -> Some String.Empty |> Task.FromResult)
             UrlBuilder = fun _ -> String.Empty
             CancellationToken = CancellationToken.None
             Logger = None
@@ -151,7 +147,3 @@ module Context =
     /// Set the metrics (IMetrics) to use.
     let withMetrics (metrics: IMetrics) (context: HttpContext) =
         { context with Request = { context.Request with Metrics = metrics } }
-
-    /// Set the authorization handler.
-    let withAuthorization (func: CancellationToken -> Task<string option>) (context: HttpContext) =
-        { context with Request = { context.Request with Authorize = func } }

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -151,3 +151,7 @@ module Context =
     /// Set the metrics (IMetrics) to use.
     let withMetrics (metrics: IMetrics) (context: HttpContext) =
         { context with Request = { context.Request with Metrics = metrics } }
+
+    /// Set the authorization handler.
+    let withAuthorization (func: CancellationToken -> Task<string>) (context: HttpContext) =
+        { context with Request = { context.Request with Authorize = func } }

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -47,7 +47,7 @@ and HttpRequest = {
     /// List of headers to be sent
     Headers: Map<string, string>
     /// Authorization handler
-    Authorize: (CancellationToken -> Task<string>)
+    Authorize: (CancellationToken -> Task<string option>)
     /// A function that builds the request URL based on the collected extra info.
     UrlBuilder: UrlBuilder
     /// Optional CancellationToken for cancelling the request.
@@ -89,7 +89,7 @@ module Context =
             Query = List.empty
             ResponseType = JsonValue
             Headers = [ "User-Agent", ua ] |> Map
-            Authorize = (fun _ -> Task.FromResult String.Empty)
+            Authorize = (fun _ -> Some String.Empty |> Task.FromResult)
             UrlBuilder = fun _ -> String.Empty
             CancellationToken = CancellationToken.None
             Logger = None
@@ -153,5 +153,5 @@ module Context =
         { context with Request = { context.Request with Metrics = metrics } }
 
     /// Set the authorization handler.
-    let withAuthorization (func: CancellationToken -> Task<string>) (context: HttpContext) =
+    let withAuthorization (func: CancellationToken -> Task<string option>) (context: HttpContext) =
         { context with Request = { context.Request with Authorize = func } }

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -43,7 +43,7 @@ and HttpRequest = {
     Query: seq<struct (string * string)>
     /// Responsetype. JSON or Protobuf
     ResponseType: ResponseType
-    /// List of headers to be sent
+    /// Map of headers to be sent
     Headers: Map<string, string>
     /// A function that builds the request URL based on the collected extra info.
     UrlBuilder: UrlBuilder

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -40,14 +40,14 @@ module Fetch =
             | JsonValue -> "Accept", "application/json"
             | Protobuf -> "Accept", "application/protobuf"
 
-        for header, value in acceptHeader :: ctx.Request.Headers do
+        for KeyValue(header, value) in ctx.Request.Headers.Add(acceptHeader) do
             if not (client.DefaultRequestHeaders.Contains header) then
                 request.Headers.Add (header, value)
 
         let content = ctx.Request.ContentBuilder |> Option.map (fun builder -> builder ())
         match content with
         | Some content -> request.Content <- content
-        | None -> ()
+        | _ -> ()
         request
 
     /// Fetch content using the given context. Exposes `{Url}`, `{ResponseContent}`, `{RequestContent}` and `{Elapsed}`
@@ -56,11 +56,7 @@ module Fetch =
         let timer = Stopwatch ()
         let client = ctx.Request.HttpClient ()
 
-        use source = new CancellationTokenSource()
-        let cancellationToken =
-            match ctx.Request.CancellationToken with
-            | Some token -> token
-            | None -> source.Token
+        let cancellationToken = ctx.Request.CancellationToken
 
         task {
             try

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -148,9 +148,9 @@ module Handler =
         return! next { Request = context.Request; Response = Ok values }
     }
 
-    /// Use the given token provider to get a bearer token to use. This enables e.g. token refresh.
-    let withTokenProvider<'TResult, 'TError> (provider: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
-        let! token = provider ctx.Request.CancellationToken
+    /// Use the given token provider to return a bearer token to use. This enables e.g. token refresh.
+    let withTokenProvider<'TResult, 'TError> (tokenProvider: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
+        let! token = tokenProvider ctx.Request.CancellationToken
         let ctx' =
             match token with
             | Some token -> Context.withBearerToken token ctx

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -148,9 +148,9 @@ module Handler =
         return! next { Request = context.Request; Response = Ok values }
     }
 
-    /// Authorize this request, setting bearer token. This enables e.g. token refresh.
-    let authorize<'TResult, 'TError> (authorize: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
-        let! token = authorize ctx.Request.CancellationToken
+    /// Use the given token provider to get a bearer token to use. This enables e.g. token refresh.
+    let withTokenProvider<'TResult, 'TError> (provider: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
+        let! token = provider ctx.Request.CancellationToken
         let ctx' =
             match token with
             | Some token -> Context.withBearerToken token ctx

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -4,6 +4,7 @@ namespace Oryx
 
 open System.IO
 open System.Net.Http
+open System.Threading
 open System.Threading.Tasks
 
 open FSharp.Control.Tasks.V2.ContextInsensitive
@@ -148,8 +149,8 @@ module Handler =
     }
 
     /// Authorize this request, setting bearer token. This enables e.g. token refresh.
-    let authorize<'TResult, 'TError> (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
-        let! token = ctx.Request.Authorize ctx.Request.CancellationToken
+    let authorize<'TResult, 'TError> (authorize: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
+        let! token = authorize ctx.Request.CancellationToken
         let ctx' =
             match token with
             | Some token -> Context.withBearerToken token ctx

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -150,6 +150,9 @@ module Handler =
     /// Authorize this request, setting bearer token. This enables e.g. token refresh.
     let authorize<'TResult, 'TError> (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
         let! token = ctx.Request.Authorize ctx.Request.CancellationToken
-        let ctx' = Context.withBearerToken token ctx
+        let ctx' =
+            match token with
+            | Some token -> Context.withBearerToken token ctx
+            | _ -> ctx
         return! next ctx'
     }

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -139,6 +139,7 @@ module Handler =
                 return Error (Panic ex)
         }
 
+    /// Extract header from response.
     let extractHeader<'T, 'TResult, 'TError> (header: string) (next: HttpFunc<_ ,_, 'TError>) (context: HttpContext) = task {
         let success, values = context.Response.Headers.TryGetValues header
         let values = if success then values else Seq.empty
@@ -146,3 +147,9 @@ module Handler =
         return! next { Request = context.Request; Response = Ok values }
     }
 
+    /// Authorize this request, setting bearer token. This enables e.g. token refresh.
+    let authorize<'TResult, 'TError> (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
+        let! token = ctx.Request.Authorize ctx.Request.CancellationToken
+        let ctx' = Context.withBearerToken token ctx
+        return! next ctx'
+    }

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -256,3 +256,23 @@ let ``Request with token provider sets Authorization header``() = task {
     | Error (Panic err) -> raise err
     | Error (ResponseError err) -> failwith (err.ToString())
 }
+
+[<Fact>]
+let ``Request with token provider without token does not set Authorization header``() = task {
+    // Arrange
+    let provider _ = Task.FromResult None
+    let ctx =
+        Context.defaultContext
+
+    let req = withTokenProvider provider >=> unit 42
+
+    // Act
+    let! result = req finishEarly ctx
+    // Assert
+    match result with
+    | Ok ctx ->
+        let found = ctx.Request.Headers.ContainsKey "Authorization"
+        test <@ not found @>
+    | Error (Panic err) -> raise err
+    | Error (ResponseError err) -> failwith (err.ToString())
+}

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -240,11 +240,11 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
 [<Fact>]
 let ``Authorize request sets Authorize header``() = task {
     // Arrange
-    let handler token = Some "token" |> Task.FromResult
+    let handler _ = Some "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
-        |> Context.withAuthorization handler
-    let req = authorize >=> unit 42
+
+    let req = authorize handler >=> unit 42
 
     // Act
     let! result = req finishEarly ctx

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -240,11 +240,11 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
 [<Fact>]
 let ``Request with token provider sets Authorization header``() = task {
     // Arrange
-    let handler _ = Some "token" |> Task.FromResult
+    let provider _ = Some "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider handler >=> unit 42
+    let req = withTokenProvider provider >=> unit 42
 
     // Act
     let! result = req finishEarly ctx

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -238,7 +238,7 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
     } |> fun x -> x.Result
 
 [<Fact>]
-let ``Authrize request sets Authorize header``() = task {
+let ``Authorize request sets Authorize header``() = task {
     // Arrange
     let handler token = Task.FromResult "token"
     let ctx =

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -238,7 +238,7 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
     } |> fun x -> x.Result
 
 [<Fact>]
-let ``Authorize request sets Authorize header``() = task {
+let ``Authorize request sets Authorization header``() = task {
     // Arrange
     let handler _ = Some "token" |> Task.FromResult
     let ctx =

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -240,7 +240,7 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
 [<Fact>]
 let ``Authorize request sets Authorize header``() = task {
     // Arrange
-    let handler token = Task.FromResult "token"
+    let handler token = Some "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
         |> Context.withAuthorization handler

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -238,13 +238,13 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
     } |> fun x -> x.Result
 
 [<Fact>]
-let ``Authorize request sets Authorization header``() = task {
+let ``Request with token provider sets Authorization header``() = task {
     // Arrange
     let handler _ = Some "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = authorize handler >=> unit 42
+    let req = withTokenProvider handler >=> unit 42
 
     // Act
     let! result = req finishEarly ctx


### PR DESCRIPTION
- Add withTokenProvider HTTP handler to authorize during request
- Simplify cancellation token by using default value instead of option type
- Make headers be a Map instead of list.

This makes it possible to refresh an auth token by using the Authorize HTTP handler that will call out (asynchronously) and return a (new) auth token.