### PR TITLE
Make withTokenProvider return a result

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The context may then be transformed using HTTP handlers. HTTP handlers are like 
 - `withUrl` - Use the given URL for the request.
 - `withUrlBuilder` - Use the given URL builder for the request.
 - `withError` - Detect if the HTTP request failed, and then fail processing.
-- `withTokenProvider` - Enables refresh of bearer tokens without building a new context.
+- `withTokenRenewer` - Enables refresh of bearer tokens without building a new context.
 
 In addition there are several extension for decoding JSON and Protobuf responses:
 

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -163,7 +163,12 @@ module Handler =
     /// Use the given token provider to return a bearer token to use. This enables e.g. token refresh. The handler will
     /// fail the request if it's unable to authenticate.
     let withTokenProvider'<'TResult, 'TError> (tokenProvider: CancellationToken -> Task<Result<string, HandlerError<'TError>>>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
-        let! result = tokenProvider ctx.Request.CancellationToken
+        let! result = task {
+            try
+                return! tokenProvider ctx.Request.CancellationToken
+            with
+            | ex -> return Panic ex |> Error
+        }
         match result with
         | Ok token ->
             let ctx = Context.withBearerToken token ctx

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -150,7 +150,7 @@ module Handler =
     }
 
     /// Use the given token provider to return a bearer token to use. This enables e.g. token refresh.
-    [<Obsolete("Do not use. Use withTokenProvider' instead.")>]
+    [<Obsolete("Do not use. Use withTokenRenewer instead.")>]
     let withTokenProvider<'TResult, 'TError> (tokenProvider: CancellationToken -> Task<string option>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
         let! token = tokenProvider ctx.Request.CancellationToken
         let ctx' =
@@ -162,7 +162,7 @@ module Handler =
 
     /// Use the given token provider to return a bearer token to use. This enables e.g. token refresh. The handler will
     /// fail the request if it's unable to authenticate.
-    let withTokenProvider'<'TResult, 'TError> (tokenProvider: CancellationToken -> Task<Result<string, HandlerError<'TError>>>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
+    let withTokenRenewer<'TResult, 'TError> (tokenProvider: CancellationToken -> Task<Result<string, HandlerError<'TError>>>) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) = task {
         let! result = task {
             try
                 return! tokenProvider ctx.Request.CancellationToken

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -239,7 +239,7 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
     } |> fun x -> x.Result
 
 [<Fact>]
-let ``Request with token provider sets Authorization header``() = task {
+let ``Request with token renewer sets Authorization header``() = task {
     // Arrange
     let renewer _ = Ok "token" |> Task.FromResult
     let ctx =
@@ -259,7 +259,7 @@ let ``Request with token provider sets Authorization header``() = task {
 }
 
 [<Fact>]
-let ``Request with token provider without token gives error``() = task {
+let ``Request with token renewer without token gives error``() = task {
     // Arrange
     let err = Exception "Unable to authenticate"
     let renewer _ = Panic err |> Error |> Task.FromResult
@@ -278,7 +278,7 @@ let ``Request with token provider without token gives error``() = task {
 }
 
 [<Fact>]
-let ``Request with token provider throws exception gives error``() = task {
+let ``Request with token renewer throws exception gives error``() = task {
     // Arrange
     let err = Exception "Unable to authenticate"
     let renewer _ = failwith "failing" |> Task.FromResult

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -13,6 +13,7 @@ open FsCheck.Arb
 open Oryx
 open Oryx.Chunk
 open Tests.Common
+open System
 
 [<Fact>]
 let ``Simple unit handler is Ok``() = task {
@@ -240,11 +241,11 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
 [<Fact>]
 let ``Request with token provider sets Authorization header``() = task {
     // Arrange
-    let provider _ = Some "token" |> Task.FromResult
+    let provider _ = Ok "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider provider >=> unit 42
+    let req = withTokenProvider' provider >=> unit 42
 
     // Act
     let! result = req finishEarly ctx
@@ -258,21 +259,39 @@ let ``Request with token provider sets Authorization header``() = task {
 }
 
 [<Fact>]
-let ``Request with token provider without token does not set Authorization header``() = task {
+let ``Request with token provider without token gives error``() = task {
     // Arrange
-    let provider _ = Task.FromResult None
+    let err = Exception "Unable to authenticate"
+    let provider _ = Panic err |> Error |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider provider >=> unit 42
+    let req = withTokenProvider' provider >=> unit 42
 
     // Act
     let! result = req finishEarly ctx
     // Assert
     match result with
-    | Ok ctx ->
-        let found = ctx.Request.Headers.ContainsKey "Authorization"
-        test <@ not found @>
-    | Error (Panic err) -> raise err
+    | Ok ctx -> failwith "Request should fail"
+    | Error (Panic err) -> test <@ err.ToString().Contains("Unable to authenticate") @>
+    | Error (ResponseError err) -> failwith (err.ToString())
+}
+
+[<Fact>]
+let ``Request with token provider throws exception gives error``() = task {
+    // Arrange
+    let err = Exception "Unable to authenticate"
+    let provider _ = failwith "failing"
+    let ctx =
+        Context.defaultContext
+
+    let req = withTokenProvider' provider >=> unit 42
+
+    // Act
+    let! result = req finishEarly ctx
+    // Assert
+    match result with
+    | Ok ctx -> failwith "Request should fail"
+    | Error (Panic err) -> test <@ err.ToString().Contains("failing") @>
     | Error (ResponseError err) -> failwith (err.ToString())
 }

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -241,11 +241,11 @@ let ``Chunked handlers is Ok`` (PositiveInt chunkSize) (PositiveInt maxConcurren
 [<Fact>]
 let ``Request with token provider sets Authorization header``() = task {
     // Arrange
-    let provider _ = Ok "token" |> Task.FromResult
+    let renewer _ = Ok "token" |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider' provider >=> unit 42
+    let req = withTokenRenewer renewer >=> unit 42
 
     // Act
     let! result = req finishEarly ctx

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -281,7 +281,7 @@ let ``Request with token provider without token gives error``() = task {
 let ``Request with token provider throws exception gives error``() = task {
     // Arrange
     let err = Exception "Unable to authenticate"
-    let provider _ = failwith "failing"
+    let provider _ = failwith "failing" |> Task.FromResult
     let ctx =
         Context.defaultContext
 

--- a/test/Handler.fs
+++ b/test/Handler.fs
@@ -262,11 +262,11 @@ let ``Request with token provider sets Authorization header``() = task {
 let ``Request with token provider without token gives error``() = task {
     // Arrange
     let err = Exception "Unable to authenticate"
-    let provider _ = Panic err |> Error |> Task.FromResult
+    let renewer _ = Panic err |> Error |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider' provider >=> unit 42
+    let req = withTokenRenewer renewer >=> unit 42
 
     // Act
     let! result = req finishEarly ctx
@@ -281,11 +281,11 @@ let ``Request with token provider without token gives error``() = task {
 let ``Request with token provider throws exception gives error``() = task {
     // Arrange
     let err = Exception "Unable to authenticate"
-    let provider _ = failwith "failing" |> Task.FromResult
+    let renewer _ = failwith "failing" |> Task.FromResult
     let ctx =
         Context.defaultContext
 
-    let req = withTokenProvider' provider >=> unit 42
+    let req = withTokenRenewer renewer >=> unit 42
 
     // Act
     let! result = req finishEarly ctx


### PR DESCRIPTION
- Then we know what happened in case something went wrong
- Make extra function to avoid breaking change
- Mark original function as obsolete