### PR TITLE
add configurable request completion

### DIFF
--- a/src/Context.fs
+++ b/src/Context.fs
@@ -60,6 +60,7 @@ and HttpRequest = {
     /// Extra state used to e.g build the URL. Clients are free to utilize this property for adding extra information to
     /// the context.
     Items: Map<string, Value>
+    CompletionMode : HttpCompletionOption
 }
 
 type Context<'T> = {
@@ -93,6 +94,7 @@ module Context =
             LogFormat = defaultLogFormat
             Metrics = EmptyMetrics ()
             Items = Map.empty
+            CompletionMode = HttpCompletionOption.ResponseContentRead
         }
 
     let defaultResult = new HttpResponseMessage (HttpStatusCode.NotFound)

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -65,7 +65,7 @@ module Fetch =
                 // Note: we don't use `use!` for response since the next handler will never throw exceptions. Thus we
                 // can dispose ourselves which is much faster than using `use!`.
                 ctx.Request.Metrics.Counter Metric.FetchInc Map.empty 1L
-                let! response = client.SendAsync (request, cancellationToken)
+                let! response = client.SendAsync (request, ctx.Request.CompletionMode, cancellationToken)
                 timer.Stop ()
                 ctx.Request.Metrics.Gauge Metric.FetchLatencyUpdate Map.empty (float timer.ElapsedMilliseconds)
                 let items = ctx.Request.Items.Add(PlaceHolder.Url, Url request.RequestUri).Add(PlaceHolder.Elapsed, Number timer.ElapsedMilliseconds)

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -175,3 +175,12 @@ module Handler =
             return! next ctx
         | Error err -> return err |> Error
     }
+
+
+    /// Use the given `completionMode` to change when the Response is considered to be 'complete'.
+    ///
+    /// Using `HttpCompletionOption.ResponseContentRead` (the default) means that the entire response content will be available in-memory when the handle response completes. This can lead to lower throughput in situations where files are being received over HTTP.
+    ///
+    /// In such cases, using `HttpCompletionOption.ResponseHeadersRead` can lead to faster response times overall, while not forcing the file stream to buffer in memory.
+    let withCompletion<'TResult, 'TError> (completionMode: HttpCompletionOption) (next: HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: HttpContext) =
+        next { ctx with Request = { ctx.Request with CompletionMode = completionMode } }


### PR DESCRIPTION
Currently Oryx requires users to buffer the entire contents of request in memory if they use the `fetch` handler to run their requests.  I'd like to configure the `HttpCompletionOption` parameter to `SendAsync` so that certain requests can be 'completed' when their headers arrive (like file transfers), so that I don't have to have that much memory on my machines, and so that my requests are actionable earlier.  

Therefore, I've added an option to the HttpRequest record and associated modification functions.  I didn't think this belonged on the context because to me it's a very per-request kind of setting. Some requests are perfectly fine waiting for the whole content.