### PR TITLE
Make sure we keep the context

### DIFF
--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -7,12 +7,12 @@ open System.Net.Http
 
 type RequestBuilder () =
     member _.Zero () : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> =
-        fun next _ ->
-            next Context.defaultContext
+        fun next ctx ->
+            next ctx
 
     member _.Return (res: 'T) : HttpHandler<HttpResponseMessage, 'T, _, 'TError> =
-        fun next _ ->
-            next { Request = Context.defaultRequest; Response = res }
+        fun next ctx ->
+            next { Request = ctx.Request; Response = res }
 
     member _.Return (req: HttpRequest) : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> =
         fun next _ ->

--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -7,8 +7,7 @@ open System.Net.Http
 
 type RequestBuilder () =
     member _.Zero () : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> =
-        fun next ctx ->
-            next ctx
+        id
 
     member _.Return (res: 'T) : HttpHandler<HttpResponseMessage, 'T, _, 'TError> =
         fun next ctx ->

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -7,7 +7,6 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.Net.Http
 open System.Net.Http.Headers
-open System.Threading
 open System.Web
 
 open FSharp.Control.Tasks.V2.ContextInsensitive

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -117,6 +117,7 @@ module Handler =
         | Error err -> return Error err
     }
 
+    /// Parse response stream to a user specified type synchronously.
     let parse<'T, 'TResult, 'TError> (parser : Stream -> 'T) (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<HttpResponseMessage>) : HttpFuncResult<'TResult, 'TError> =
         task {
             let! stream = ctx.Response.Content.ReadAsStreamAsync ()
@@ -129,6 +130,7 @@ module Handler =
                 return Error (Panic ex)
         }
 
+    /// Parse response stream to a user specified type asynchronously.
     let parseAsync<'T, 'TResult, 'TError> (parser : Stream -> Task<'T>) (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<HttpResponseMessage>) : HttpFuncResult<'TResult, 'TError> =
         task {
             let! stream = ctx.Response.Content.ReadAsStreamAsync ()


### PR DESCRIPTION
For the builder we must keep the context so we don't remove stuff like loggers when using the `req` builder.