### PR TITLE
[CDF-5689] Change logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,12 +468,14 @@ You can also use a custom log format string by setting the log format using `wit
 
 **Note:** Oryx will not call `.ToString ()` but will hand it over to the `ILogger` for the actual string interpolation, given that the message will actually end up being logged.
 
-There are to logging handlers. One without a message and one where you can supply a custom message that may be added to the logging output (see format string). The logging handlers do not alter the types of the pipeline and may be composed anywhere. But to give meaningful output they should be composed after fetching (`fetch`).
+NOTE: The logging handler (`log`) do not alter the types of the pipeline and may be composed anywhere. But to give meaningful output they should be composed after fetching (`fetch`) but before error handling (`withError`). This is because fetch related values goes down the pipeline while error values short-circuits and goes up. So you need to log in between to catch both.
 
 ```fs
-val log : next: HttpFunc<'T, 'TResult, 'TError> -> ctx : Context<'T>  -> HttpFuncResult<'TResult, 'TError>
+val withLogger: logger : ILogger -> next: HttpFunc<HttpResponseMessage,'T,'TError> -> context: HttpContext -> HttpFuncResult<'T,'TError>
+val withLogLevel: logLevel: LogLevel -> next: HttpFunc<HttpResponseMessage,'T,'TError> -> context : HttpContext -> HttpFuncResult<'T,'TError>
+val withLogMessage: msg: string -> next: HttpFunc<HttpResponseMessage,'T,'TError> -> context: HttpContext -> HttpFuncResult<'T,'TError>
 
-val logWithMessage : msg: string -> next: HttpFunc<'T, 'TResult, 'TError> -> ctx : Context<'T> -> HttpFuncResult<'TResult, 'TError>
+val log : next: HttpFunc<'T, 'TResult, 'TError> -> ctx : Context<'T>  -> HttpFuncResult<'TResult, 'TError>
 ```
 
 Oryx may also emit metrics using the `IMetrics` interface (Oryx specific) that you can use with e.g Prometheus.

--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -6,16 +6,10 @@ open System.Net.Http
 
 
 type RequestBuilder () =
-    member _.Zero () : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> =
-        id
+    member _.Zero () : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> = id
 
     member _.Return (res: 'T) : HttpHandler<HttpResponseMessage, 'T, _, 'TError> =
-        fun next ctx ->
-            next { Request = ctx.Request; Response = res }
-
-    member _.Return (req: HttpRequest) : HttpHandler<HttpResponseMessage, HttpResponseMessage, _, 'err> =
-        fun next _ ->
-            next { Request = req; Response = Context.defaultResult }
+        fun next ctx -> next { Request = ctx.Request; Response = res }
 
     member _.ReturnFrom (req : HttpHandler<'T, 'TNext, 'TResult, 'TError>) : HttpHandler<'T, 'TNext, 'TResult, 'TError> = req
 

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -30,6 +30,27 @@ type Value =
         | Number num -> num.ToString ()
         | Url uri -> uri.ToString ()
 
+
+module PlaceHolder =
+    [<Literal>]
+    let HttpMethod = "HttpMethod"
+
+    [<Literal>]
+    let RequestContent = "RequestContent"
+
+    [<Literal>]
+    let ResponseContent = "ResponseContent"
+
+    [<Literal>]
+    let Message = "Message"
+
+    [<Literal>]
+    let Url = "Url"
+
+    [<Literal>]
+    let Elapsed = "Elapsed"
+
+
 type UrlBuilder = HttpRequest -> string
 
 and HttpRequest = {
@@ -145,6 +166,10 @@ module Context =
     /// Set the log format to use.
     let withLogFormat (format: string) (context: HttpContext) =
         { context with Request = { context.Request with LogFormat = format } }
+
+    /// Set the log format to use.
+    let withLogMessage (msg: string) (context: HttpContext) =
+        { context with Request = { context.Request with Items = context.Request.Items.Add (PlaceHolder.Message, String msg) } }
 
     /// Set the metrics (IMetrics) to use.
     let withMetrics (metrics: IMetrics) (context: HttpContext) =

--- a/src/Context.fs
+++ b/src/Context.fs
@@ -167,7 +167,7 @@ module Context =
     let withLogFormat (format: string) (context: HttpContext) =
         { context with Request = { context.Request with LogFormat = format } }
 
-    /// Set the log format to use.
+    /// Set the log message to use (normally you would like to use the withLogMessage handler instead)
     let withLogMessage (msg: string) (context: HttpContext) =
         { context with Request = { context.Request with Items = context.Request.Items.Add (PlaceHolder.Message, String msg) } }
 

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -68,7 +68,7 @@ module Fetch =
                 timer.Stop ()
                 ctx.Request.Metrics.Gauge Metric.FetchLatencyUpdate Map.empty (float timer.ElapsedMilliseconds)
                 let items = ctx.Request.Items.Add(PlaceHolder.Url, Url request.RequestUri).Add(PlaceHolder.Elapsed, Number timer.ElapsedMilliseconds)
-                let! result = next { ctx with Response = response; Request = { ctx.Request with Items = items }}
+                let! result = next { ctx with Request = { ctx.Request with Items = items }; Response = response; }
                 response.Dispose ()
                 return result
             with

--- a/src/Handler.fs
+++ b/src/Handler.fs
@@ -15,6 +15,11 @@ type HandlerError<'TError> =
     | Panic of exn
     /// User defined error response.
     | ResponseError of 'TError
+    with
+        override this.ToString() =
+            match this with
+            | Panic exn -> exn.ToString()
+            | ResponseError err -> err.ToString()
 
 type HttpFuncResult<'TResult, 'TError> =  Task<Result<Context<'TResult>, HandlerError<'TError>>>
 

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -8,25 +8,6 @@ open System.Text.RegularExpressions
 open Microsoft.Extensions.Logging
 open FSharp.Control.Tasks.V2.ContextInsensitive
 
-module PlaceHolder =
-    [<Literal>]
-    let HttpMethod = "HttpMethod"
-
-    [<Literal>]
-    let RequestContent = "RequestContent"
-
-    [<Literal>]
-    let ResponseContent = "ResponseContent"
-
-    [<Literal>]
-    let Message = "Message"
-
-    [<Literal>]
-    let Url = "Url"
-
-    [<Literal>]
-    let Elapsed = "Elapsed"
-
 [<AutoOpen>]
 module Logging =
 
@@ -36,53 +17,57 @@ module Logging =
     let withLogLevel (logLevel: LogLevel) (next: HttpFunc<HttpResponseMessage,'T, 'TError>) (context: HttpContext) =
         next { context with Request = { context.Request with LogLevel = logLevel } }
 
+    let withLogMessage (msg: string) (next: HttpFunc<HttpResponseMessage,'T, 'TError>) (context: HttpContext) =
+        next { context with Request = { context.Request with Items = context.Request.Items.Add (PlaceHolder.Message, Value.String msg)  } }
+
     // Pre-compiled
     let private reqex = Regex(@"\{(.+?)\}", RegexOptions.Multiline ||| RegexOptions.Compiled)
 
-    /// Logger handler with message. Needs to be composed in the request after the fetch handler.
-    let logWithMessage (msg: string) (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<'T>) : HttpFuncResult<'TResult, 'TError> =
-        task {
-            let! ctx' = next ctx
-            let request = ctx.Request
-            let format = ctx.Request.LogFormat                               
-            match request.Logger, request.LogLevel with
-            | _, LogLevel.None -> ()                
-            | Some logger, _ ->
-                match ctx' with
-                | Ok res ->
-                    printfn "%A" res.Response
-                    let matches = reqex.Matches format
-                    // Create an array with values in the same order as in the format string. Important to be lazy and not
-                    // stringify any values here. Only pass references to the objects themselves so the logger can stringify
-                    // when / if the values are acutally being used / logged.
-                    let valueArray =
-                        matches
-                        |> Seq.cast
-                        |> Seq.map (fun (matche: Match) ->
-                            match matche.Groups.[1].Value with
-                            | PlaceHolder.HttpMethod -> box request.Method
-                            | PlaceHolder.RequestContent ->
-                                ctx.Request.ContentBuilder
-                                |> Option.map (fun builder -> builder ())
-                                |> Option.toObj :> _
-                            | PlaceHolder.ResponseContent -> res.Response :> _
-                            | PlaceHolder.Message -> msg :> _
-                            | key ->
-                                // Look for the key in the extra info. This also enables custom HTTP handlers to add custom
-                                // placeholders to the format string.
-                                match ctx.Request.Items.TryFind key with
-                                | Some value -> value :> _
-                                | _ -> String.Empty :> _
-                        )
-                        |> Array.ofSeq
-                    logger.Log (request.LogLevel, format, valueArray)
-                | Error err ->
-                    logger.Log (LogLevel.Error, format, err)
-            | _ -> ()     
+    [<Obsolete("Do not use. Use log / withLogMessage instead.")>]
+    let logWithMessage (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<'T>) : HttpFuncResult<'TResult, 'TError> =
+        next ctx
 
-            return ctx'
+    /// Logger handler with message. Needs to be composed in the request before the fetch handler.
+    let log (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<'T>) : HttpFuncResult<'TResult, 'TError> =
+        task {
+            let! result = next ctx
+
+            match ctx.Request.Logger, ctx.Request.LogLevel with
+            | _, LogLevel.None -> ()
+            | Some logger, _ ->
+                let format = ctx.Request.LogFormat
+                let request = ctx.Request
+                let matches = reqex.Matches format
+
+                // Create an array with values in the same order as in the format string. Important to be lazy and not
+                // stringify any values here. Only pass references to the objects themselves so the logger can stringify
+                // when / if the values are acutally being used / logged.
+                let getValues response =
+                    matches
+                    |> Seq.cast
+                    |> Seq.map (fun (matche: Match) ->
+                        match matche.Groups.[1].Value with
+                        | PlaceHolder.HttpMethod -> box request.Method
+                        | PlaceHolder.RequestContent ->
+                            ctx.Request.ContentBuilder
+                            |> Option.map (fun builder -> builder ())
+                            |> Option.toObj :> _
+                        | PlaceHolder.ResponseContent -> response :> _
+                        | key ->
+                            // Look for the key in the extra info. This also enables custom HTTP handlers to add custom
+                            // placeholders to the format string.
+                            match ctx.Request.Items.TryFind key with
+                            | Some value -> value :> _
+                            | _ -> String.Empty :> _
+                    )
+                    |> Array.ofSeq
+
+                let level, values =
+                    match result with
+                    | Ok ctx' -> request.LogLevel, getValues ctx'.Response
+                    | Error err -> LogLevel.Error, getValues err
+                logger.Log (level, format, values)
+            | _ -> ()
+            return result
         }
 
-    /// Logger handler. Needs to be composed in the request after the fetch handler.
-    let log (next: HttpFunc<'T, 'TResult, 'TError>) (ctx : Context<'T>) : HttpFuncResult<'TResult, 'TError> =
-        logWithMessage String.Empty next ctx

--- a/test/Fetch.fs
+++ b/test/Fetch.fs
@@ -246,7 +246,7 @@ let ``Post with logging is OK``() = task {
 
     // Act
     let request = req {
-        let! result = post content >=> logWithMessage msg
+        let! result = logWithMessage msg >=> post content 
         return result
     }
 


### PR DESCRIPTION
Change logging to withLogMessage / log instead of logWithMessage in order to move log in between `fetch` and `withError`, so we also log errors.