### PR TITLE
Add examples.fsproj with Oryx.ThothJsonNet example

### DIFF
--- a/examples/Program.fs
+++ b/examples/Program.fs
@@ -1,0 +1,56 @@
+open System.Net.Http
+open System.Text.Json
+
+open FSharp.Control.Tasks.V2.ContextInsensitive
+
+open Oryx
+open Oryx.ThothJsonNet.ResponseReader
+open Thoth.Json.Net
+
+type WikiSearchHit = 
+    | SearchTerm of string
+    | SearchHits of string list
+
+type WikiSearchHits = WikiSearchHits of WikiSearchHit list
+
+let wikiDataItemDecoder : Decoder<WikiSearchHit> =
+    Decode.oneOf [
+        Decode.string |> Decode.map SearchTerm
+        Decode.list Decode.string |> Decode.map SearchHits
+    ]
+
+let wikiDataItemsDecoders : Decoder<WikiSearchHits> =
+    Decode.list wikiDataItemDecoder
+    |> Decode.map WikiSearchHits
+
+[<Literal>]
+let Url = "https://en.wikipedia.org/w/api.php"
+
+let options = JsonSerializerOptions()
+
+let query term = [
+    struct ("action", "opensearch")
+    struct ("search", term)
+]
+
+let request term =
+    GET
+    >=> withUrl Url
+    >=> withQuery (query term)
+    >=> fetch
+    >=> json wikiDataItemsDecoders
+
+let asyncMain argv = task {
+    use client = new HttpClient ()
+    let ctx =
+        Context.defaultContext
+        |> Context.withHttpClient client
+
+    let! result = request "F#" |> runAsync ctx
+    printfn "Result: %A" result
+}
+
+[<EntryPoint>]
+let main argv =
+    asyncMain().GetAwaiter().GetResult()
+    0 // return an integer exit code

--- a/examples/examples.fsproj
+++ b/examples/examples.fsproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Oryx.fsproj" />
+    <ProjectReference Include="..\extensions\Oryx.ThothJsonNet\Oryx.ThothJsonNet.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/examples/paket.references
+++ b/examples/paket.references
@@ -1,0 +1,1 @@
+Thoth.Json.Net

--- a/examples/paket.references
+++ b/examples/paket.references
@@ -1,1 +1,2 @@
+group Examples
 Thoth.Json.Net

--- a/oryx.sln
+++ b/oryx.sln
@@ -19,6 +19,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Oryx.NewtonsoftJson", "exte
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Oryx.ThothJsonNet", "extensions\Oryx.ThothJsonNet\Oryx.ThothJsonNet.fsproj", "{535AE660-B32C-4833-8C7B-A8DAEA8799E1}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "examples", "examples\examples.fsproj", "{755A4763-1976-41A1-91A2-FFB772343479}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -116,6 +118,18 @@ Global
 		{535AE660-B32C-4833-8C7B-A8DAEA8799E1}.Release|x64.Build.0 = Release|Any CPU
 		{535AE660-B32C-4833-8C7B-A8DAEA8799E1}.Release|x86.ActiveCfg = Release|Any CPU
 		{535AE660-B32C-4833-8C7B-A8DAEA8799E1}.Release|x86.Build.0 = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|x64.Build.0 = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Debug|x86.Build.0 = Debug|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|Any CPU.Build.0 = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|x64.ActiveCfg = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|x64.Build.0 = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|x86.ActiveCfg = Release|Any CPU
+		{755A4763-1976-41A1-91A2-FFB772343479}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EDBBC8E4-1CAF-41BA-B945-6AC59717D720} = {C9E10FD9-70B4-421A-BDB1-421F5901CB7C}

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,6 +7,7 @@ group Main
     nuget Microsoft.Extensions.Logging
     nuget FSharp.Core ~> 4.7
     nuget Taskbuilder.fs ~> 2.1
+nuget Thoth.Json.Net
 
 group Json
     source https://www.nuget.org/api/v2

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,7 +7,7 @@ group Main
     nuget Microsoft.Extensions.Logging
     nuget FSharp.Core ~> 4.7
     nuget Taskbuilder.fs ~> 2.1
-nuget Thoth.Json.Net
+
 
 group Json
     source https://www.nuget.org/api/v2
@@ -72,3 +72,9 @@ group Benchmark
     nuget Thoth.Json.Net
     nuget Utf8Json
     nuget Ply
+
+group Examples
+    source https://www.nuget.org/api/v2
+    storage: none
+    
+    nuget Thoth.Json.Net

--- a/paket.lock
+++ b/paket.lock
@@ -2,9 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    Fable.Core (3.1.5)
-      FSharp.Core (>= 4.7)
-    FSharp.Core (4.7)
+    FSharp.Core (4.7.2)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)
     Microsoft.Extensions.Configuration (3.1.1)
@@ -33,7 +31,6 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Newtonsoft.Json (12.0.3)
     System.Buffers (4.5)
     System.ComponentModel.Annotations (4.7)
     System.Memory (4.5.3)
@@ -49,10 +46,6 @@ NUGET
       FSharp.Core (>= 4.1.17)
       NETStandard.Library (>= 1.6.1)
       System.ValueTuple (>= 4.4)
-    Thoth.Json.Net (4.1)
-      Fable.Core (>= 3.0 < 4.0)
-      FSharp.Core (>= 4.6.2)
-      Newtonsoft.Json (>= 11.0.2)
 
 GROUP Benchmark
 STORAGE: NONE
@@ -701,6 +694,19 @@ NUGET
       System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
       System.Threading.Tasks.Extensions (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
       System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
+
+GROUP Examples
+STORAGE: NONE
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Fable.Core (3.1.5) - restriction: && (< net46) (>= netstandard2.0)
+      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
+    FSharp.Core (4.7.2) - restriction: || (>= net46) (>= netstandard2.0)
+    Newtonsoft.Json (12.0.3) - restriction: || (>= net46) (>= netstandard2.0)
+    Thoth.Json.Net (4.1)
+      Fable.Core (>= 3.0 < 4.0) - restriction: && (< net46) (>= netstandard2.0)
+      FSharp.Core (>= 4.6.2) - restriction: || (>= net46) (>= netstandard2.0)
+      Newtonsoft.Json (>= 11.0.2) - restriction: || (>= net46) (>= netstandard2.0)
 
 GROUP Google
 STORAGE: NONE

--- a/paket.lock
+++ b/paket.lock
@@ -2,6 +2,8 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
+    Fable.Core (3.1.5)
+      FSharp.Core (>= 4.7)
     FSharp.Core (4.7)
     Microsoft.Bcl.AsyncInterfaces (1.1)
       System.Threading.Tasks.Extensions (>= 4.5.2)
@@ -31,6 +33,7 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
+    Newtonsoft.Json (12.0.3)
     System.Buffers (4.5)
     System.ComponentModel.Annotations (4.7)
     System.Memory (4.5.3)
@@ -46,6 +49,10 @@ NUGET
       FSharp.Core (>= 4.1.17)
       NETStandard.Library (>= 1.6.1)
       System.ValueTuple (>= 4.4)
+    Thoth.Json.Net (4.1)
+      Fable.Core (>= 3.0 < 4.0)
+      FSharp.Core (>= 4.6.2)
+      Newtonsoft.Json (>= 11.0.2)
 
 GROUP Benchmark
 STORAGE: NONE


### PR DESCRIPTION
I've added a runnable Oryx.ThothJsonNet example based on the example in Readme.md.

IMLE (in my limited experience) Thoth makes a better job of showing  what causes an error and it also makes it a lot easier to map strange json to sensible f# types. 

I've set up the examples project to have project reference dependencies to all Oryx parts but paket dependencies to everything else.

Use or modify this PR as you find suitable.