### PR TITLE
Simplify OnNextAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ let request term =
 let asyncMain argv = task {
     use client = new HttpClient ()
     let ctx =
-        Context.defaultContext
-        |> Context.withHttpClient client
+        HttpContext.defaultContext
+        |> HttpContext.withHttpClient client
 
     let! result = request "F#" |> runAsync ctx
     printfn "Result: %A" result

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ source = handler.Subscribe(result)
 
 An HTTP handler (`IHttpHandler`) is a middleware that subscribes `.Subscribe()` the given HTTP next handler
 (`IHttpNext<'TResult>`), and also returns the source HTTP next (`IHttpNext<'TSource>`). The returned
-`IHttpNext<'TSource>` is used to write the `Context` and thel content (`'TSource`) into the handler.
+`IHttpNext<'TSource>` is used to write the `Context` and content (`'TSource`) into the handler.
 The given result (`IHttpNext<'Result>`) is where the `HttpHandler` will write its output. You can think of the
 `IHttpNext` as the input and output next functions (or observers / continuations) of the `HttpHandler`.
 

--- a/examples/github/Program.fs
+++ b/examples/github/Program.fs
@@ -1,8 +1,9 @@
-open Oryx
 open System.Net.Http
+
+open FSharp.Control.Tasks
+open Oryx
 open Oryx.ThothJsonNet.ResponseReader
 open Thoth.Json.Net
-open FSharp.Control.Tasks
 
 [<EntryPoint>]
 let main argv =
@@ -12,21 +13,19 @@ let main argv =
         Context.defaultContext
         |> Context.withHttpClient client
 
-    let response =
+    let request =
         GET
         >=> withUrl "https://api.github.com/repos/cognitedata/oryx/releases/latest"
         >=> fetch
         >=> json (Decode.field "tag_name" Decode.string)
 
-    let _ =
-        (task {
-            let! tag = (response |> runAsync context)
+    task {
+        let! tag = request |> runAsync context
+        printfn "%A" tag
 
-            printfn "%A" tag
-
-            return 0
-         })
-            .GetAwaiter()
-            .GetResult()
+        return 0
+    }
+    |> (fun t -> t.GetAwaiter().GetResult())
+    |> ignore
 
     0 // return an integer exit code

--- a/src/HttpHandler/Builder.fs
+++ b/src/HttpHandler/Builder.fs
@@ -4,6 +4,7 @@
 namespace Oryx
 
 open Oryx.Middleware
+open FSharp.Control.Tasks
 
 type RequestBuilder () =
     member _.Zero() : IHttpHandler<'TSource> =
@@ -27,7 +28,28 @@ type RequestBuilder () =
             source: IHttpHandler<'TSource, 'TValue>,
             fn: 'TValue -> IHttpHandler<'TSource, 'TResult>
         ) : IHttpHandler<'TSource, 'TResult> =
-        source >=> Core.bind fn
+        { new IHttpHandler<'TSource, 'TResult> with
+            member _.Subscribe(next) =
+                { new IHttpNext<'TSource> with
+                    member _.OnNextAsync(ctx, content) =
+                        let valueObs =
+                            { new IHttpNext<'TValue> with
+                                member _.OnNextAsync(ctx, value) =
+                                    task {
+                                        let bound : IHttpHandler<'TSource, 'TResult> = fn value
+                                        return! bound.Subscribe(next).OnNextAsync(ctx, content)
+                                    }
+
+                                member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
+                                member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) }
+
+                        task {
+                            let sourceObv = source.Subscribe(valueObs)
+                            return! sourceObv.OnNextAsync(ctx, content)
+                        }
+
+                    member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
+                    member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
 
 [<AutoOpen>]
 module Builder =

--- a/src/HttpHandler/HttpHandler.fs
+++ b/src/HttpHandler/HttpHandler.fs
@@ -36,9 +36,6 @@ module HttpHandler =
     /// Map the content of the HTTP handler.
     let map<'TContext, 'TSource, 'TResult> = Core.map<HttpContext, 'TSource, 'TResult>
 
-    /// Bind the content of the middleware.
-    //let bind<'TContext, 'TSource, 'TResult> = Core.bind<HttpContext, 'TSource, 'TResult>
-
     /// Add query parameters to context. These parameters will be added
     /// to the query string of requests that uses this context.
     let withQuery (query: seq<struct (string * string)>) : IHttpHandler<'TSource> =

--- a/src/HttpHandler/HttpHandler.fs
+++ b/src/HttpHandler/HttpHandler.fs
@@ -57,11 +57,11 @@ module HttpHandler =
         Core.chunk<HttpContext, 'TSource, 'TNext, 'TResult> HttpContext.merge
 
     /// Run list of HTTP handlers sequentially.
-    let sequential<'TContext, 'TSource, 'TResult> =
+    let sequential<'TSource, 'TResult> =
         Core.sequential<HttpContext, 'TSource, 'TResult> HttpContext.merge
 
     /// Run list of HTTP handlers concurrently.
-    let concurrent<'TContext, 'TSource, 'TResult> =
+    let concurrent<'TSource, 'TResult> =
         Core.concurrent<HttpContext, 'TSource, 'TResult> HttpContext.merge
 
     /// Catch handler for catching errors and then delegating to the error handler on what to do.
@@ -71,7 +71,13 @@ module HttpHandler =
     let choose<'TSource, 'TResult> = Error.choose<HttpContext, 'TSource, 'TResult>
 
     /// Error handler for forcing error. Use with e.g `req` computational expression if you need to "return" an error.
-    let throw<'TContext, 'TSource, 'TResult> = throw<HttpContext, 'TSource, 'TResult>
+    let throw<'TSource, 'TResult> = throw<HttpContext, 'TSource, 'TResult>
+
+    /// Validate content using a predicate function.
+    let validate<'TSource> = Core.validate<HttpContext, 'TSource>
+
+    /// Handler that ignores the content and outputs unit.
+    let ignore<'TSource> = Core.ignore<HttpContext, 'TSource>
 
     /// Parse response stream to a user specified type synchronously.
     let parse<'TResult> (parser: Stream -> 'TResult) : IHttpHandler<HttpContent, 'TResult> =

--- a/src/HttpHandler/HttpHandler.fs
+++ b/src/HttpHandler/HttpHandler.fs
@@ -16,12 +16,12 @@ type IHttpHandler<'TSource> = IHttpHandler<'TSource, 'TSource>
 [<AutoOpen>]
 module HttpHandler =
     /// Run the HTTP handler in the given context. Returns content as result type.
-    let runAsync<'TSource, 'TResult> (ctx: HttpContext) (handler: IHttpHandler<unit, 'TResult>) =
-        Core.runAsync<HttpContext, unit, 'TResult> ctx handler
+    let runAsync<'TResult> (ctx: HttpContext) (handler: IHttpHandler<unit, 'TResult>) =
+        Core.runAsync<HttpContext, 'TResult> ctx handler
 
     /// Run the HTTP handler in the given context. Returns content and throws exception if any error occured.
-    let runUnsafeAsync<'TSource, 'TResult> (ctx: HttpContext) (handler: IHttpHandler<unit, 'TResult>) =
-        Core.runUnsafeAsync<HttpContext, 'TSource, 'TResult> ctx handler
+    let runUnsafeAsync<'TResult> (ctx: HttpContext) (handler: IHttpHandler<unit, 'TResult>) =
+        Core.runUnsafeAsync<HttpContext, 'TResult> ctx handler
 
     /// Compose two HTTP handlers into one.
     let inline compose (first: IHttpHandler<'T1, 'T2>) (second: IHttpHandler<'T2, 'T3>) : IHttpHandler<'T1, 'T3> =

--- a/src/HttpHandler/Logging.fs
+++ b/src/HttpHandler/Logging.fs
@@ -18,13 +18,13 @@ module Logging =
         { new IHttpHandler<'TSource> with
             member _.Subscribe(next) =
                 { new IHttpNext<'TSource> with
-                    member _.OnNextAsync(ctx, ?content) =
+                    member _.OnNextAsync(ctx, content) =
                         next.OnNextAsync(
                             { ctx with
                                   Request =
                                       { ctx.Request with
                                             Logger = Some logger } },
-                            ?content = content
+                            content = content
                         )
 
                     member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
@@ -35,11 +35,11 @@ module Logging =
         { new IHttpHandler<'TSource> with
             member _.Subscribe(next) =
                 { new IHttpNext<'TSource> with
-                    member _.OnNextAsync(ctx, ?content) =
+                    member _.OnNextAsync(ctx, content) =
                         next.OnNextAsync(
                             { ctx with
                                   Request = { ctx.Request with LogLevel = logLevel } },
-                            ?content = content
+                            content = content
                         )
 
                     member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
@@ -50,13 +50,13 @@ module Logging =
         { new IHttpHandler<'TSource> with
             member _.Subscribe(next) =
                 { new IHttpNext<'TSource> with
-                    member _.OnNextAsync(ctx, ?content) =
+                    member _.OnNextAsync(ctx, content) =
                         next.OnNextAsync(
                             { ctx with
                                   Request =
                                       { ctx.Request with
                                             Items = ctx.Request.Items.Add(PlaceHolder.Message, Value.String msg) } },
-                            ?content = content
+                            content = content
                         )
 
                     member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
@@ -93,10 +93,7 @@ module Logging =
                                         |> Option.map (fun builder -> builder ())
                                         |> Option.toObj
                                         :> _
-                                    | PlaceHolder.ResponseContent ->
-                                        match response with
-                                        | Some content -> content :> _
-                                        | None -> null
+                                    | PlaceHolder.ResponseContent -> content :> _
                                     | key ->
                                         // Look for the key in the extra info. This also enables custom HTTP handlers to add custom
                                         // placeholders to the format string.
@@ -110,13 +107,13 @@ module Logging =
                     | _ -> ()
 
                 { new IHttpNext<'TSource> with
-                    member _.OnNextAsync(ctx, ?content) =
+                    member _.OnNextAsync(ctx, content) =
                         task {
                             match ctx.Request.LogLevel with
                             | LogLevel.None -> ()
                             | logLevel -> log logLevel ctx content
 
-                            return! next.OnNextAsync(ctx, ?content = content)
+                            return! next.OnNextAsync(ctx, content = content)
                         }
 
                     member _.OnErrorAsync(ctx, exn) =

--- a/src/Middleware/Builder.fs
+++ b/src/Middleware/Builder.fs
@@ -33,28 +33,7 @@ type MiddlewareBuilder () =
             source: IAsyncMiddleware<'TContext, 'TSource, 'TValue>,
             fn: 'TValue -> IAsyncMiddleware<'TContext, 'TSource, 'TResult>
         ) : IAsyncMiddleware<'TContext, 'TSource, 'TResult> =
-        { new IAsyncMiddleware<'TContext, 'TSource, 'TResult> with
-            member _.Subscribe(next) =
-                { new IAsyncNext<'TContext, 'TSource> with
-                    member _.OnNextAsync(ctx, content) =
-                        let valueObs =
-                            { new IAsyncNext<'TContext, 'TValue> with
-                                member _.OnNextAsync(ctx, value) =
-                                    task {
-                                        let bound : IAsyncMiddleware<'TContext, 'TSource, 'TResult> = fn value
-                                        return! bound.Subscribe(next).OnNextAsync(ctx, content)
-                                    }
-
-                                member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
-                                member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) }
-
-                        task {
-                            let sourceObv = source.Subscribe(valueObs)
-                            return! sourceObv.OnNextAsync(ctx, content)
-                        }
-
-                    member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
-                    member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
+        source |> Core.bind fn
 
 [<AutoOpen>]
 module Builder =

--- a/src/Middleware/Core.fs
+++ b/src/Middleware/Core.fs
@@ -28,7 +28,7 @@ module Core =
             member _.OnCompletedAsync _ = task { tcs.SetCanceled() } }
 
     /// Run the HTTP handler in the given context. Returns content as result type.
-    let runAsync<'TContext, 'TSource, 'TResult>
+    let runAsync<'TContext, 'TResult>
         (ctx: 'TContext)
         (handler: IAsyncMiddleware<'TContext, unit, 'TResult>)
         : Task<Result<'TResult, exn>> =
@@ -44,7 +44,7 @@ module Core =
         }
 
     /// Run the HTTP handler in the given context. Returns content and throws exception if any error occured.
-    let runUnsafeAsync<'TContext, 'TSource, 'TResult>
+    let runUnsafeAsync<'TContext, 'TResult>
         (ctx: 'TContext)
         (handler: IAsyncMiddleware<'TContext, unit, 'TResult>)
         : Task<'TResult> =

--- a/src/Middleware/Core.fs
+++ b/src/Middleware/Core.fs
@@ -77,6 +77,34 @@ module Core =
                     member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
                     member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
 
+    /// Bind the content of the middleware.
+    let bind<'TContext, 'TSource, 'TValue, 'TResult>
+        (fn: 'TValue -> IAsyncMiddleware<'TContext, 'TSource, 'TResult>)
+        (source: IAsyncMiddleware<'TContext, 'TSource, 'TValue>)
+        : IAsyncMiddleware<'TContext, 'TSource, 'TResult> =
+        { new IAsyncMiddleware<'TContext, 'TSource, 'TResult> with
+            member _.Subscribe(next) =
+                { new IAsyncNext<'TContext, 'TSource> with
+                    member _.OnNextAsync(ctx, content) =
+                        let valueObs =
+                            { new IAsyncNext<'TContext, 'TValue> with
+                                member _.OnNextAsync(ctx, value) =
+                                    task {
+                                        let bound : IAsyncMiddleware<'TContext, 'TSource, 'TResult> = fn value
+                                        return! bound.Subscribe(next).OnNextAsync(ctx, content)
+                                    }
+
+                                member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
+                                member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) }
+
+                        task {
+                            let sourceObv = source.Subscribe(valueObs)
+                            return! sourceObv.OnNextAsync(ctx, content)
+                        }
+
+                    member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
+                    member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
+
     /// Compose two middlewares into one.
     let inline compose
         (first: IAsyncMiddleware<'TContext, 'T1, 'T2>)

--- a/src/Middleware/Core.fs
+++ b/src/Middleware/Core.fs
@@ -74,25 +74,8 @@ module Core =
             member _.Subscribe(next) =
                 { new IAsyncNext<'TContext, 'TSource> with
                     member _.OnNextAsync(ctx, content) = next.OnNextAsync(ctx, mapper content)
-
                     member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
                     member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
-
-    /// Bind the content of the middleware.
-    // let bind<'TContext, 'TSource, 'TResult>
-    //     (fn: 'TSource -> IAsyncMiddleware<'TContext, 'TSource, 'TResult>)
-    //     : IAsyncMiddleware<'TContext, 'TSource, 'TResult> =
-    //     { new IAsyncMiddleware<'TContext, 'TSource, 'TResult> with
-    //         member _.Subscribe(next) =
-    //             { new IAsyncNext<'TContext, 'TSource> with
-    //                 member _.OnNextAsync(ctx, content) =
-    //                     task {
-    //                         let bound : IAsyncMiddleware<'TContext, 'TSource, 'TResult> = fn content
-    //                         return! bound.Subscribe(next).OnNextAsync(ctx, content)
-    //                     }
-
-    //                 member _.OnErrorAsync(ctx, exn) = next.OnErrorAsync(ctx, exn)
-    //                 member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) } }
 
     /// Compose two middlewares into one.
     let inline compose
@@ -120,7 +103,6 @@ module Core =
                             let obv n =
                                 { new IAsyncNext<'TContext, 'TResult> with
                                     member _.OnNextAsync(ctx, content) = task { res.[n] <- Ok(ctx, content) }
-
                                     member _.OnErrorAsync(_, err) = task { res.[n] <- Error err }
                                     member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) }
 
@@ -157,7 +139,6 @@ module Core =
                             let obv =
                                 { new IAsyncNext<'TContext, 'TResult> with
                                     member _.OnNextAsync(ctx, content) = task { Ok(ctx, content) |> res.Add }
-
                                     member _.OnErrorAsync(_, err) = task { Error err |> res.Add }
                                     member _.OnCompletedAsync(ctx) = next.OnCompletedAsync(ctx) }
 

--- a/test/Builder.fs
+++ b/test/Builder.fs
@@ -47,7 +47,7 @@ let ``Simple return from unit handler in builder is Ok`` () =
         // Arrange
         let ctx = HttpContext.defaultContext
 
-        let a = singleton 42 |> runAsync ctx
+        let a = singleton 42 >=> ignore |> runAsync ctx
 
         // Act
         let! result = req { return! singleton 42 } |> runUnsafeAsync ctx
@@ -67,7 +67,10 @@ let ``Multiple handlers in builder is Ok`` () =
             req {
                 let! a = singleton 10
                 let! b = singleton 20
-                return! add a b
+
+                return!
+                    add a b
+                    >=> validate (fun value -> value = 10 + 20)
             }
 
         let! result = request |> runUnsafeAsync ctx

--- a/test/Builder.fs
+++ b/test/Builder.fs
@@ -18,7 +18,7 @@ let ``Zero builder is Ok`` () =
         let! result = req { () } |> runAsync ctx
 
         // Assert
-        test <@ Result.isError result @>
+        test <@ Result.isOk result @>
     }
 
 [<Fact>]


### PR DESCRIPTION
Simplify OnNextAsync by making content non-optional. This removes the need for having to pattern match in every handler. In many cases the content needed to be `unit` for handlers and `unit option` feels unnecessary. 

Also make `choose` operator trigger on error instead of success. I.e it will continue to the next handler as long as the current handler produces error. This allows for handlers to not produce output and still be considered successful.