### PR TITLE
Handle embedded version if the physical DLL does not exist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup tools
         run: dotnet tool restore
       - name: Dotnet Pack
-        run: dotnet pack -c release -p:PackageVersion=${GITHUB_REF##*/v} -p:FileVersion=${GITHUB_REF##*/v}
+        run: dotnet pack -c release -p:PackageVersion=${GITHUB_REF##*/v} -p:FileVersion=${GITHUB_REF##*/v} -p:InformationalVersion=${GITHUB_REF##*/v}
 
       - name: Push Oryx Nuget
         run: dotnet nuget push src/bin/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}

--- a/src/HttpHandler/HttpContext.fs
+++ b/src/HttpHandler/HttpContext.fs
@@ -107,11 +107,8 @@ type HttpContext =
 [<RequireQualifiedAccess>]
 module HttpContext =
     let private fileVersion =
-        FileVersionInfo
-            .GetVersionInfo(
-                Assembly.GetExecutingAssembly().Location
-            )
-            .FileVersion
+        Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            .InformationalVersion
 
     let defaultLogFormat =
         "Oryx: {Message} {HttpMethod} {Url}\n→ {RequestContent}\n← {ResponseContent}"


### PR DESCRIPTION
See https://github.com/cognitedata/cognite-sdk-dotnet/pull/248/files, the issue still occurs since it is also present in Oryx. This is the same fix, which is confirmed to work even if there is no physical assembly. It may also be a bit more flexible, since InformationalVersion has no restrictions on structure.