### PR TITLE
Update README, simplify naming

### DIFF
--- a/src/HttpHandler/Fetch.fs
+++ b/src/HttpHandler/Fetch.fs
@@ -66,7 +66,7 @@ module Fetch =
     /// Fetch content using the given context. Exposes `{Url}`, `{ResponseContent}`, `{RequestContent}` and `{Elapsed}`
     /// to the log format.
     let fetch<'TSource> (source: HttpHandler<'TSource>) : HttpHandler<HttpContent> =
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             fun ctx _ ->
                 task {
                     let timer = Stopwatch()
@@ -96,7 +96,7 @@ module Fetch =
                             |> Map.ofSeq
 
                         let! result =
-                            onSuccess
+                            success
                                 { Request = { ctx.Request with Items = items }
                                   Response =
                                     { StatusCode = response.StatusCode
@@ -109,6 +109,6 @@ module Fetch =
                         response.Dispose()
                         return result
                     with
-                    | ex when not (ex :? HttpException) -> return! onError ctx (HttpException(ctx, ex))
+                    | ex when not (ex :? HttpException) -> return! error ctx (HttpException(ctx, ex))
                 }
-            |> Core.swapArgs source onError onCancel
+            |> Core.swapArgs source error cancel

--- a/src/Pipeline/Core.fs
+++ b/src/Pipeline/Core.fs
@@ -25,11 +25,11 @@ module Core =
     let finish<'TContext, 'TResult>
         (tcs: TaskCompletionSource<'TResult>)
         : OnSuccessAsync<'TContext, 'TResult> * OnErrorAsync<'TContext> * OnCancelAsync<'TContext> =
-        let onSuccess _ response = task { tcs.SetResult response }
-        let onError _ (error: exn) = task { tcs.SetException error }
-        let onCancel _ = task { tcs.SetCanceled() }
+        let success _ response = task { tcs.SetResult response }
+        let error _ (err: exn) = task { tcs.SetException err }
+        let cancel _ = task { tcs.SetCanceled() }
 
-        (onSuccess, onError, onCancel)
+        (success, error, cancel)
 
     /// Run the HTTP handler in the given context. Returns content and throws exception if any error occured.
     let runUnsafeAsync<'TContext, 'TResult> (handler: Pipeline<'TContext, 'TResult>) : Task<'TResult> =
@@ -52,7 +52,7 @@ module Core =
 
     /// Produce the given content.
     let singleton<'TContext, 'TSource> (ctx: 'TContext) (content: 'TSource) : Pipeline<'TContext, 'TSource> =
-        fun onSuccess onError onCancel -> task { do! onSuccess ctx content }
+        fun success _ _ -> task { do! success ctx content }
 
     /// Map the content of the middleware.
     let map<'TContext, 'TSource, 'TResult>

--- a/src/Pipeline/Core.fs
+++ b/src/Pipeline/Core.fs
@@ -60,8 +60,8 @@ module Core =
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TResult> =
 
-        fun onSuccess ->
-            fun ctx content -> onSuccess ctx (mapper content)
+        fun succes ->
+            fun ctx content -> succes ctx (mapper content)
             |> source
 
     /// Bind the content of the middleware.
@@ -69,19 +69,19 @@ module Core =
         (fn: 'TSource -> Pipeline<'TContext, 'TResult>)
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TResult> =
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             fun _ value ->
                 task {
                     let handler = fn value
-                    return! handler onSuccess onError onCancel
+                    return! handler success error cancel
                 }
-            |> swapArgs source onError onCancel
+            |> swapArgs source error cancel
 
     let concurrent<'TContext, 'TSource, 'TResult>
         (merge: 'TContext list -> 'TContext)
         (handlers: seq<Pipeline<'TContext, 'TResult>>)
         : Pipeline<'TContext, 'TResult list> =
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             task {
                 let res: Result<'TContext * 'TResult, 'TContext * exn> array =
                     Array.zeroCreate (Seq.length handlers)
@@ -90,7 +90,7 @@ module Core =
 
                 let tasks =
                     handlers
-                    |> Seq.mapi (fun n handler -> handler (obv n) onError onCancel)
+                    |> Seq.mapi (fun n handler -> handler (obv n) error cancel)
 
                 let! _ = Task.WhenAll(tasks)
 
@@ -100,7 +100,7 @@ module Core =
                 | Ok results ->
                     let results, contents = results |> List.unzip
                     let bs = merge results
-                    return! onSuccess bs contents
+                    return! success bs contents
                 | Error (_, err) -> raise err
             }
 
@@ -109,14 +109,14 @@ module Core =
         (merge: 'TContext list -> 'TContext)
         (handlers: seq<Pipeline<'TContext, 'TResult>>)
         : Pipeline<'TContext, 'TResult list> =
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             task {
                 let res = ResizeArray<Result<'TContext * 'TResult, 'TContext * exn>>()
 
                 let obv ctx content = task { Ok(ctx, content) |> res.Add }
 
                 for handler in handlers do
-                    do! handler obv onError onCancel
+                    do! handler obv error cancel
 
                 let result = res |> List.ofSeq |> List.sequenceResultM
 
@@ -124,7 +124,7 @@ module Core =
                 | Ok results ->
                     let results, contents = results |> List.unzip
                     let bs = merge results
-                    return! onSuccess bs contents
+                    return! success bs contents
                 | Error (_, err) -> raise err
             }
 
@@ -146,25 +146,25 @@ module Core =
 
     /// Handler that skips (ignores) the content and outputs unit.
     let ignoreContent<'TContext, 'TSource> (source: Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, unit> =
-        fun onSuccess ->
-            fun ctx _ -> onSuccess ctx ()
+        fun success ->
+            fun ctx _ -> success ctx ()
             |> source
 
     let cache<'TContext, 'TSource> (source: Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, 'TSource> =
         let mutable cache: ('TContext * 'TSource) option = None
 
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             task {
                 match cache with
-                | Some (ctx, content) -> return! onSuccess ctx content
+                | Some (ctx, content) -> return! success ctx content
                 | _ ->
                     return!
                         fun ctx content ->
                             task {
                                 cache <- Some(ctx, content)
-                                return! onSuccess ctx content
+                                return! success ctx content
                             }
-                        |> swapArgs source onError onCancel
+                        |> swapArgs source error cancel
             }
 
     /// Never produces a result.
@@ -178,11 +178,11 @@ module Core =
         (predicate: 'TSource -> bool)
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TSource> =
-        fun onSuccess ->
+        fun success ->
             fun ctx value ->
                 task {
                     if predicate value then
-                        return! onSuccess ctx value
+                        return! success ctx value
                 }
             |> source
 
@@ -191,13 +191,13 @@ module Core =
         (predicate: 'TSource -> bool)
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TSource> =
-        fun onSuccess onError onCancel ->
+        fun success error cancel ->
             fun ctx value ->
                 if predicate value then
-                    onSuccess ctx value
+                    success ctx value
                 else
                     raise (SkipException "Validation failed")
-            |> swapArgs source onError onCancel
+            |> swapArgs source error cancel
 
     /// Retrieves the content.
     let await<'TContext, 'TSource> () (source: Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, 'TSource> =
@@ -205,8 +205,8 @@ module Core =
 
     /// Returns the current environment.
     let ask<'TContext, 'TSource> (source: Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, 'TContext> =
-        fun onSuccess ->
-            fun ctx _ -> onSuccess ctx ctx
+        fun success ->
+            fun ctx _ -> success ctx ctx
             |> source
 
     /// Update (asks) the context.
@@ -214,8 +214,8 @@ module Core =
         (update: 'TContext -> 'TContext)
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TSource> =
-        fun onSuccess ->
-            fun ctx -> onSuccess (update ctx)
+        fun success ->
+            fun ctx -> success (update ctx)
             |> source
 
     /// Replaces the value with a constant.

--- a/src/Pipeline/Error.fs
+++ b/src/Pipeline/Error.fs
@@ -52,7 +52,7 @@ module Error =
         (source: Pipeline<'TContext, 'TSource>)
         : Pipeline<'TContext, 'TSource> =
         fun success error cancel ->
-            let onSuccess' ctx content =
+            let success' ctx content =
                 task {
                     try
                         return! success ctx content
@@ -60,14 +60,14 @@ module Error =
                     | err when not (err :? PanicException) -> return! (errorHandler ctx err) success error cancel
                 }
 
-            let onError' ctx err =
+            let error' ctx err =
                 task {
                     match err with
                     | PanicException err -> return! error ctx err
                     | _ -> do! (errorHandler ctx err) success error cancel
                 }
 
-            source onSuccess' onError' cancel
+            source success' error' cancel
 
     [<RequireQualifiedAccess>]
     type ChooseState =

--- a/src/Pipeline/Error.fs
+++ b/src/Pipeline/Error.fs
@@ -10,7 +10,7 @@ open Oryx
 
 module Error =
     /// Handler for protecting the pipeline from exceptions and protocol violations.
-    let protect<'TContext, 'TSource> (source : Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, 'TSource> =
+    let protect<'TContext, 'TSource> (source: Pipeline<'TContext, 'TSource>) : Pipeline<'TContext, 'TSource> =
         fun success error cancel ->
             let mutable stopped = false
 
@@ -20,7 +20,8 @@ module Error =
                     | false ->
                         try
                             return! success ctx content
-                        with err ->
+                        with
+                        | err ->
                             stopped <- true
                             return! error ctx err
                     | _ -> ()
@@ -43,9 +44,9 @@ module Error =
                         return! cancel ctx
                     | _ -> ()
                 }
-            
+
             source success' error' cancel'
-            
+
     /// Handler for catching errors and then delegating to the error handler on what to do.
     let catch<'TContext, 'TSource>
         (errorHandler: 'TContext -> exn -> Pipeline<'TContext, 'TSource>)

--- a/test/Common.fs
+++ b/test/Common.fs
@@ -74,15 +74,15 @@ let panic msg source : HttpHandler<'TSource> =
     panic (TestException(code = 400, message = msg)) source
 
 /// A bad request handler to use with the `catch` handler. It takes a response to return as Ok.
-let badRequestHandler<'TSource> (response: 'TSource) (ctx: HttpContext) (error: exn) : HttpHandler<'TSource> =
-    fun onSuccess _ _ ->
+let badRequestHandler<'TSource> (response: 'TSource) (ctx: HttpContext) (err: exn) : HttpHandler<'TSource> =
+    fun success _ _ ->
         task {
-            match error with
-            | TestException (code, message) ->
+            match err with
+            | TestException (code, _) ->
                 match enum<HttpStatusCode> code with
-                | HttpStatusCode.BadRequest -> return! onSuccess ctx response
-                | _ -> raise (HttpException(ctx, error))
-            | _ -> raise (HttpException(ctx, error))
+                | HttpStatusCode.BadRequest -> return! success ctx response
+                | _ -> raise (HttpException(ctx, err))
+            | _ -> raise (HttpException(ctx, err))
         }
 
 let errorHandler (response: HttpResponse) (_: HttpContent) =


### PR DESCRIPTION
- Update README
- For simplicity rename `onSuccess`, `onError` and `onCancel` to just `success`, `error` and `cancel`. 
- Re-add `protect` operator