### PR TITLE
Updated to FsToolkit.ErrorHandling (3.0)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fantomas": {
-      "version": "5.0.1",
+      "version": "5.0.6",
       "commands": [
         "fantomas"
       ]

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,7 +7,7 @@ group Main
     nuget FSharp.Core ~> 6
     nuget Microsoft.Extensions.Logging ~> 6
     nuget Microsoft.Extensions.DependencyInjection ~> 6
-    nuget FsToolkit.ErrorHandling ~> 2
+    nuget FsToolkit.ErrorHandling ~> 3
 
 group Json
     source https://www.nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -3,7 +3,7 @@ RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
     FSharp.Core (6.0.6)
-    FsToolkit.ErrorHandling (2.13)
+    FsToolkit.ErrorHandling (3.0)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (6.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)


### PR DESCRIPTION
@dbrattli because of the new FsToolkit.ErrorHandling 3.0 toolkit release I have its version downgrade when I use Oryx, so I updated its version. Let me know if that is the right way you intent that to be.