### PR TITLE
Fix FSharp.Core to 7

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,6 @@ group Main
 
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget Microsoft.Extensions.Logging >= 6 lowest_matching: true
     nuget Microsoft.Extensions.DependencyInjection >= 6 lowest_matching: true
     nuget FsToolkit.ErrorHandling ~> 4
@@ -15,7 +14,6 @@ group Json
 
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget System.Text.Json >= 6 lowest_matching: true
     nuget Oryx
 
@@ -25,7 +23,6 @@ group Newtonsoft
 
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget Newtonsoft.Json
     nuget Microsoft.NETCore.Platforms >= 6 lowest_matching: true
     nuget Oryx
@@ -36,7 +33,6 @@ group Thoth
 
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget Thoth.Json.Net
     nuget Oryx
 
@@ -46,7 +42,6 @@ group Google
 
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget Google.Protobuf ~> 3
     nuget Microsoft.NETCore.Platforms >= 6 lowest_matching: true
     nuget Oryx
@@ -55,7 +50,6 @@ group Test
     source https://www.nuget.org/api/v2
     storage: none
 
-    nuget FSharp.Core >= 6 lowest_matching: true
     nuget coverlet.msbuild ~> 3
     nuget Unquote ~> 5
     nuget xunit ~> 2

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,6 +4,7 @@ group Main
 
     framework: netstandard2.0
 
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Microsoft.Extensions.Logging >= 6 lowest_matching: true
     nuget Microsoft.Extensions.DependencyInjection >= 6 lowest_matching: true
     nuget FsToolkit.ErrorHandling ~> 4
@@ -14,6 +15,7 @@ group Json
 
     framework: netstandard2.0
 
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget System.Text.Json >= 6 lowest_matching: true
     nuget Oryx
 
@@ -23,6 +25,7 @@ group Newtonsoft
 
     framework: netstandard2.0
 
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Newtonsoft.Json
     nuget Microsoft.NETCore.Platforms >= 6 lowest_matching: true
     nuget Oryx
@@ -33,6 +36,7 @@ group Thoth
 
     framework: netstandard2.0
 
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Thoth.Json.Net
     nuget Oryx
 
@@ -42,6 +46,7 @@ group Google
 
     framework: netstandard2.0
 
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Google.Protobuf ~> 3
     nuget Microsoft.NETCore.Platforms >= 6 lowest_matching: true
     nuget Oryx
@@ -50,6 +55,7 @@ group Test
     source https://www.nuget.org/api/v2
     storage: none
 
+    nuget FSharp.Core
     nuget coverlet.msbuild ~> 3
     nuget Unquote ~> 5
     nuget xunit ~> 2

--- a/paket.lock
+++ b/paket.lock
@@ -2,8 +2,8 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
-    FsToolkit.ErrorHandling (4.5)
+    FSharp.Core (7.0.300)
+    FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)
@@ -51,8 +51,8 @@ STORAGE: NONE
 NUGET
   remote: https://www.nuget.org/api/v2
     Fable.Core (4.0) - restriction: && (< net46) (>= netstandard2.0)
-    FSharp.Core (7.0.200) - restriction: || (>= net46) (>= netstandard2.0)
-    FsToolkit.ErrorHandling (3.3.1) - restriction: >= netstandard2.0
+    FSharp.Core (7.0.300) - restriction: || (>= net46) (>= netstandard2.0)
+    FsToolkit.ErrorHandling (4.6) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: && (>= netstandard2.0) (< netstandard2.1)
       FSharp.Core (>= 7.0) - restriction: >= netstandard2.1
     Microsoft.Bcl.AsyncInterfaces (7.0) - restriction: || (&& (>= net462) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1))
@@ -144,13 +144,13 @@ NUGET
       System.Runtime.Serialization.Formatters (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (&& (< net20) (>= netstandard1.0) (< netstandard1.3)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0))
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
-    Oryx (5.2.1)
+    Oryx (5.3.2)
       FSharp.Core (>= 6.0) - restriction: >= netstandard2.0
-      FsToolkit.ErrorHandling (>= 3.3.1 < 4.0) - restriction: >= netstandard2.0
+      FsToolkit.ErrorHandling (>= 4.5 < 5.0) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 6.0) - restriction: >= netstandard2.0
-    Oryx.ThothJsonNet (5.2.1)
+    Oryx.ThothJsonNet (5.3.2)
       FSharp.Core (>= 6.0) - restriction: >= netstandard2.0
-      Oryx (>= 5.2) - restriction: >= netstandard2.0
+      Oryx (>= 5.2.1) - restriction: >= netstandard2.0
       Thoth.Json.Net (>= 11.0) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monotouch) (< net20) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net20) (>= net46) (< netstandard1.3) (>= netstandard1.6)) (&& (< net20) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net20) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net20) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net20) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net20) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< netstandard1.3) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monotouch) (< net20) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net20) (>= net46) (< netstandard1.3) (>= netstandard1.6)) (&& (< net20) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net20) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net20) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net20) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net20) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< netstandard1.3) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
@@ -688,10 +688,10 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
-    FsToolkit.ErrorHandling (3.3.1)
+    FSharp.Core (7.0.300)
+    FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
-    Google.Protobuf (3.22.3)
+    Google.Protobuf (3.23.1)
       System.Memory (>= 4.5.3)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -721,9 +721,9 @@ NUGET
       System.Memory (>= 4.5.5)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
     Microsoft.NETCore.Platforms (6.0)
-    Oryx (5.2.1)
+    Oryx (5.3.2)
       FSharp.Core (>= 6.0)
-      FsToolkit.ErrorHandling (>= 3.3.1 < 4.0)
+      FsToolkit.ErrorHandling (>= 4.5 < 5.0)
       Microsoft.Extensions.Logging (>= 6.0)
     System.Buffers (4.5.1)
     System.ComponentModel.Annotations (5.0)
@@ -744,8 +744,8 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
-    FsToolkit.ErrorHandling (3.3.1)
+    FSharp.Core (7.0.300)
+    FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)
@@ -773,9 +773,9 @@ NUGET
     Microsoft.Extensions.Primitives (7.0)
       System.Memory (>= 4.5.5)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
-    Oryx (5.2.1)
+    Oryx (5.3.2)
       FSharp.Core (>= 6.0)
-      FsToolkit.ErrorHandling (>= 3.3.1 < 4.0)
+      FsToolkit.ErrorHandling (>= 4.5 < 5.0)
       Microsoft.Extensions.Logging (>= 6.0)
     System.Buffers (4.5.1)
     System.ComponentModel.Annotations (5.0)
@@ -808,8 +808,8 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
-    FsToolkit.ErrorHandling (3.3.1)
+    FSharp.Core (7.0.300)
+    FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)
@@ -839,9 +839,9 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
     Microsoft.NETCore.Platforms (6.0)
     Newtonsoft.Json (13.0.3)
-    Oryx (5.2.1)
+    Oryx (5.3.2)
       FSharp.Core (>= 6.0)
-      FsToolkit.ErrorHandling (>= 3.3.1 < 4.0)
+      FsToolkit.ErrorHandling (>= 4.5 < 5.0)
       Microsoft.Extensions.Logging (>= 6.0)
     System.Buffers (4.5.1)
     System.ComponentModel.Annotations (5.0)
@@ -869,18 +869,18 @@ NUGET
     FsCheck.Xunit (2.16.5)
       FsCheck (2.16.5)
       xunit.extensibility.execution (>= 2.2 < 3.0)
-    FSharp.Core (6.0)
-    Microsoft.CodeCoverage (17.5) - restriction: || (>= net462) (>= netcoreapp3.1)
-    Microsoft.NET.Test.Sdk (17.5)
-      Microsoft.CodeCoverage (>= 17.5) - restriction: || (>= net462) (>= netcoreapp3.1)
-      Microsoft.TestPlatform.TestHost (>= 17.5) - restriction: >= netcoreapp3.1
+    FSharp.Core (7.0.300) - restriction: >= netstandard1.0
+    Microsoft.CodeCoverage (17.6) - restriction: || (>= net462) (>= netcoreapp3.1)
+    Microsoft.NET.Test.Sdk (17.6)
+      Microsoft.CodeCoverage (>= 17.6) - restriction: || (>= net462) (>= netcoreapp3.1)
+      Microsoft.TestPlatform.TestHost (>= 17.6) - restriction: >= netcoreapp3.1
     Microsoft.NETCore.Platforms (7.0.2) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.2) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (>= net45) (< net452) (< netstandard1.3)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.2) (>= netstandard1.5) (< win8)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (< net452) (>= net46) (< netstandard1.4)) (&& (< net452) (>= net461)) (>= netcoreapp2.0) (&& (< netstandard1.0) (>= netstandard1.1) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard1.1) (>= win8)) (&& (< netstandard1.0) (>= netstandard1.1) (< win8)) (&& (>= netstandard1.1) (< portable-net45+win8+wpa81)) (&& (>= netstandard1.1) (>= wp8)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (>= netstandard1.2) (< portable-net45+win8+wpa81)) (&& (< netstandard1.2) (>= uap10.0) (< win8)) (&& (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (>= netstandard1.5) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1)
     Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.2) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (< netstandard1.2) (>= netstandard1.5) (< win8)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net452) (>= net46) (< netstandard1.4)) (&& (>= netstandard1.1) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (>= netstandard1.2) (< portable-net45+win8+wpa81)) (&& (< netstandard1.2) (>= uap10.0) (< win8)) (&& (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard1.5) (< portable-net45+win8+wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< win81) (< wpa81))
-    Microsoft.TestPlatform.ObjectModel (17.5) - restriction: >= netcoreapp3.1
+    Microsoft.TestPlatform.ObjectModel (17.6) - restriction: >= netcoreapp3.1
       NuGet.Frameworks (>= 5.11) - restriction: || (>= net462) (>= netstandard2.0)
       System.Reflection.Metadata (>= 1.6) - restriction: || (>= net462) (>= netstandard2.0)
-    Microsoft.TestPlatform.TestHost (17.5) - restriction: >= netcoreapp3.1
-      Microsoft.TestPlatform.ObjectModel (>= 17.5) - restriction: >= netcoreapp3.1
+    Microsoft.TestPlatform.TestHost (17.6) - restriction: >= netcoreapp3.1
+      Microsoft.TestPlatform.ObjectModel (>= 17.6) - restriction: >= netcoreapp3.1
       Newtonsoft.Json (>= 13.0.1) - restriction: >= netcoreapp3.1
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net452) (>= net46) (< netstandard1.4)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -932,7 +932,7 @@ NUGET
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
     Newtonsoft.Json (13.0.3) - restriction: || (>= net46) (>= netstandard2.0)
-    NuGet.Frameworks (6.5) - restriction: >= netcoreapp3.1
+    NuGet.Frameworks (6.6) - restriction: >= netcoreapp3.1
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
@@ -1431,8 +1431,8 @@ RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
     Fable.Core (4.0)
-    FSharp.Core (6.0)
-    FsToolkit.ErrorHandling (3.3.1)
+    FSharp.Core (7.0.300)
+    FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)
@@ -1461,9 +1461,9 @@ NUGET
       System.Memory (>= 4.5.5)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
     Newtonsoft.Json (13.0.3)
-    Oryx (5.2.1)
+    Oryx (5.3.2)
       FSharp.Core (>= 6.0)
-      FsToolkit.ErrorHandling (>= 3.3.1 < 4.0)
+      FsToolkit.ErrorHandling (>= 4.5 < 5.0)
       Microsoft.Extensions.Logging (>= 6.0)
     System.Buffers (4.5.1)
     System.ComponentModel.Annotations (5.0)

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (7.0.300)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -688,7 +688,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (7.0.300)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Google.Protobuf (3.23.1)
@@ -744,7 +744,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (7.0.300)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -808,7 +808,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (7.0.300)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -869,7 +869,7 @@ NUGET
     FsCheck.Xunit (2.16.5)
       FsCheck (2.16.5)
       xunit.extensibility.execution (>= 2.2 < 3.0)
-    FSharp.Core (7.0.300) - restriction: >= netstandard1.0
+    FSharp.Core (7.0.300)
     Microsoft.CodeCoverage (17.6) - restriction: || (>= net462) (>= netcoreapp3.1)
     Microsoft.NET.Test.Sdk (17.6)
       Microsoft.CodeCoverage (>= 17.6) - restriction: || (>= net462) (>= netcoreapp3.1)
@@ -1431,7 +1431,7 @@ RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
     Fable.Core (4.0)
-    FSharp.Core (7.0.300)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)


### PR DESCRIPTION
We have a transitive dependency on this, and the current setup causes a package downgrade error in all downstream packages, requiring them all to pick a version of FSharp.Core, which isn't great, especially as most downstream packages aren't written in F#.

The error happens because FsToolkit.ErrorHandling depends on FSharp.Core 7.

This also needs to be changed in the SDK.