### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.200
+          dotnet-version: 8.0.407
       - name: Setup dotnet tools
         run: dotnet tool restore
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.200
+          dotnet-version: 8.0.407
 
       - name: Get version
         id: get-version
         run: echo "version=$(cat version)" >> $GITHUB_OUTPUT
-        
+
       - name: Get branch
         id: get-branch
         run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
-        
+
       - name: Confirm release
         id: confirm-release
         run: echo "test=$(git tag --list 'v${{ steps.get-version.outputs.version }}' | wc -l | sed s/\ //g)" >> $GITHUB_OUTPUT
@@ -60,7 +60,7 @@ jobs:
           name: nuget-packages
           path: nuget-packages/
           retention-days: 1
-  
+
   publish:
     name: Create Release
     runs-on: windows-latest

--- a/examples/github/GitHub.fsproj
+++ b/examples/github/GitHub.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />

--- a/examples/wikisearch/WikiSearch.fsproj
+++ b/examples/wikisearch/WikiSearch.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Oryx.fsproj" />

--- a/test/Tests.fsproj
+++ b/test/Tests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateProgramFile>false</GenerateProgramFile>


### PR DESCRIPTION
Upgrade repo to build using .NET 8 instead of .NET 6. It doesn't really matter since the library built is for `netstandard2.0` which works for both `net6` and `net8` but the Fantomas formatter now requires `net8`, so we need this in order to fix #160 

So, no changes to the library, only the environment where it's built.